### PR TITLE
Improve upstream sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,4 +19,4 @@ jobs:
         github_repository: "${GITHUB_REPOSITORY}"
         github_token: ${{ secrets.WORKFLOW_TOKEN }}
         upstream_repo: debezium/debezium
-        major_version: "2"
+        version_regex: "^v2\\.[0-9]+\\.[0-9]+\\.Final$"


### PR DESCRIPTION
This PR fixes the workflow that syncs and rebases on upstream changes.

It leverages a new version of the DataDog/sync-upstream-release-tag GitHub action: https://github.com/DataDog/sync-upstream-release-tag/pull/13