### PR TITLE
Update sync workflow to fetch tags from 3.x

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,4 +19,4 @@ jobs:
         github_repository: "${GITHUB_REPOSITORY}"
         github_token: ${{ secrets.WORKFLOW_TOKEN }}
         upstream_repo: debezium/debezium
-        version_regex: "^v2\\.[0-9]+\\.[0-9]+\\.Final$"
+        version_regex: "^v3\\.[0-9]+\\.[0-9]+\\.Final$"


### PR DESCRIPTION
The sync workflow was scoped to fetching only 2.x tags

Since Debezium 3.x is out, let's start pulling this tag in.

(workflow action reference: https://github.com/DataDog/sync-upstream-release-tag/tree/main)