### PR TITLE
ActivateTracingSpan SMT: emit traces when no propagated context is provided

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
@@ -116,20 +116,16 @@ public class ActivateTracingSpan<R extends ConnectRecord<R>> implements Transfor
             propagatedSpanContext = after.getString(spanContextField);
         }
 
-        if (propagatedSpanContext == null) {
-            if (requireContextField) {
-                return connectRecord;
-            }
+        if (propagatedSpanContext == null && requireContextField) {
+            return connectRecord;
         }
-        else {
-            try {
-                return TracingSpanUtil.traceRecord(connectRecord, envelope, source, propagatedSpanContext, operationName);
-            }
-            catch (NoClassDefFoundError e) {
-                throw new DebeziumException("Failed to record tracing information, tracing libraries not available", e);
-            }
+
+        try {
+            return TracingSpanUtil.traceRecord(connectRecord, envelope, source, propagatedSpanContext, operationName);
         }
-        return connectRecord;
+        catch (NoClassDefFoundError e) {
+            throw new DebeziumException("Failed to record tracing information, tracing libraries not available", e);
+        }
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/transforms/tracing/TracingSpanUtil.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/tracing/TracingSpanUtil.java
@@ -39,42 +39,58 @@ public class TracingSpanUtil {
 
     }
 
+    /**
+     * Create tracing spans representing the write operation in the database (the span timestamp is taken
+     * from the source event if available), as well as Debezium's processing operation (the span timestamp
+     * is taken from the envelope's timestamp).
+     * If a trace context is provided for propagation, it is set as the parent context of the
+     * created spans to enable distributed tracing.
+     * The resulting context is injected in the Kafka Connect Record headers for further propagation.
+     *
+     * @param <R> the subtype of {@link ConnectRecord} on which this transformation will operate
+     * @param connectRecord the Connect record that is to be enriched with tracing information
+     * @param envelope the envelope wrapped by the record
+     * @param source the source field of the envelope, or {@code null}
+     * @param propagatedSpanContext a String serialization of a {@link java.util.Properties} instance representing
+     *   the parent span context that should be used for trace propagation, or {@code null}
+     * @param operationName the operation name of the debezium processing span
+     * @return the connect record with message headers augmented with tracing information
+     */
     public static <R extends ConnectRecord<R>> R traceRecord(R connectRecord, Struct envelope, Struct source, String propagatedSpanContext, String operationName) {
+        SpanBuilder txLogSpanBuilder = tracer.spanBuilder(TX_LOG_WRITE_OPERATION_NAME)
+                .setSpanKind(SpanKind.INTERNAL);
 
         if (propagatedSpanContext != null) {
-
             Properties props = PropertiesGetter.extract(propagatedSpanContext);
 
             Context parentSpanContext = openTelemetry.getPropagators().getTextMapPropagator()
                     .extract(Context.current(), props, PropertiesGetter.INSTANCE);
 
-            SpanBuilder txLogSpanBuilder = tracer.spanBuilder(TX_LOG_WRITE_OPERATION_NAME)
-                    .setSpanKind(SpanKind.INTERNAL)
-                    .setParent(parentSpanContext);
+            txLogSpanBuilder.setParent(parentSpanContext);
+        }
 
+        if (source != null) {
+            Long eventTimestamp = source.getInt64(AbstractSourceInfo.TIMESTAMP_KEY);
+            if (eventTimestamp != null) {
+                txLogSpanBuilder.setStartTimestamp(eventTimestamp, TimeUnit.MILLISECONDS);
+            }
+        }
+
+        Span txLogSpan = txLogSpanBuilder.startSpan();
+
+        try (Scope ignored = txLogSpan.makeCurrent()) {
             if (source != null) {
-                Long eventTimestamp = source.getInt64(AbstractSourceInfo.TIMESTAMP_KEY);
-                if (eventTimestamp != null) {
-                    txLogSpanBuilder.setStartTimestamp(eventTimestamp, TimeUnit.MILLISECONDS);
+                for (org.apache.kafka.connect.data.Field field : source.schema().fields()) {
+                    addFieldToSpan(txLogSpan, source, field.name(), DB_FIELDS_PREFIX);
                 }
             }
+            debeziumSpan(envelope, operationName);
 
-            Span txLogSpan = txLogSpanBuilder.startSpan();
-
-            try (Scope ignored = txLogSpan.makeCurrent()) {
-                if (source != null) {
-                    for (org.apache.kafka.connect.data.Field field : source.schema().fields()) {
-                        addFieldToSpan(txLogSpan, source, field.name(), DB_FIELDS_PREFIX);
-                    }
-                }
-                debeziumSpan(envelope, operationName);
-
-                TextMapPropagator textMapPropagator = openTelemetry.getPropagators().getTextMapPropagator();
-                textMapPropagator.inject(Context.current(), connectRecord.headers(), KafkaConnectHeadersSetter.INSTANCE);
-            }
-            finally {
-                txLogSpan.end();
-            }
+            TextMapPropagator textMapPropagator = openTelemetry.getPropagators().getTextMapPropagator();
+            textMapPropagator.inject(Context.current(), connectRecord.headers(), KafkaConnectHeadersSetter.INSTANCE);
+        }
+        finally {
+            txLogSpan.end();
         }
 
         return connectRecord;


### PR DESCRIPTION
Debezium offers to create traces when processing records. [The documentation](https://debezium.io/documentation/reference/stable/integrations/tracing.html#_activatetracingspan_smt) states that when provided with a serialized upstream application tracing context (through a specific SQL table field), it will use this trace context as a parent trace context for its own spans. If it doesn't find any, it will create traces and spans from scratch.

In reality, if no propagated trace context is found, Debezium skips emitting traces ([source](https://github.com/debezium/debezium/blob/v3.0.1.Final/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java#L119C1-L132C30))
```
if (propagatedSpanContext == null) {
    if (requireContextField) {
        return connectRecord;
    }
}
else {
    try {
        return TracingSpanUtil.traceRecord(connectRecord, envelope, source, propagatedSpanContext, operationName);
    }
    catch (NoClassDefFoundError e) {
        throw new DebeziumException("Failed to record tracing information, tracing libraries not available", e);
    }
}
return connectRecord;
```

The `requireContextField` parameter comes from a setting. It controls whether to trace only the records that provide a trace context.

So, [per the documentation](https://debezium.io/documentation/reference/stable/integrations/tracing.html#_activatetracingspan_smt), the following cases exist:
1. WHEN `propagatedSpanContext` is not null
  THEN create trace (and propagate span context as parent)
2. WHEN `propagatedSpanContext` is null AND requireContextField is true
  THEN skip trace creation
3. WHEN `propagatedSpanContext` is null AND requireContextField is false (default)
  THEN create trace

Case 3. is the one that this PR fixes:
* The SMT's `apply` method is modified to skip tracing when (and only when) `propagatedSpanContext == null && requireContextField`
* The `TracingSpanUtil` `traceRecord` method is improved to always create a trace while still handling the case where its `propagatedSpanContext` parameter would be `null`.