### PR TITLE
[MARS-5710] Introduce debezium-schema-translator module

### DIFF
--- a/.github/actions/build-debezium-schema-translator/action.yml
+++ b/.github/actions/build-debezium-schema-translator/action.yml
@@ -1,0 +1,25 @@
+name: "Build Debezium Schema Translator"
+description: "Builds the Debezium Schema Translator module"
+
+inputs:
+  maven-cache-key:
+    description: "The maven build cache key"
+    required: true
+  shell:
+    description: "The shell to use"
+    required: false
+    default: bash
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/setup-java
+
+    - uses: ./.github/actions/maven-cache
+      with:
+        key: ${{ inputs.maven-cache-key }}
+
+    - name: Build Debezium Schema Translator module
+      shell: ${{ inputs.shell }}
+      run: >
+        ./mvnw clean install -B -pl :debezium-schema-translator -am -amd

--- a/.github/workflows/debezium-workflow-pr.yml
+++ b/.github/workflows/debezium-workflow-pr.yml
@@ -45,6 +45,7 @@ jobs:
       documentation-only-changed: ${{ steps.changed-files-documentation.outputs.only_changed }}
       storage-only-changed: ${{ steps.changed-files-storage.outputs.only_changed }}
       extensions-changed: ${{ steps.changed-files-extensions.outputs.any_changed }}
+      schema-translator-changed: ${{ steps.changed-files-schema-translator.outputs.any_changed }}
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4
@@ -218,6 +219,13 @@ jobs:
         with:
           files: |
             debezium-openlineage/**
+
+      - name: Get modified files (Schema Translator)
+        id: changed-files-schema-translator
+        uses: tj-actions/changed-files@v46.0.5
+        with:
+          files: |
+            debezium-schema-translator/**
     
       
 
@@ -623,6 +631,18 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4
       - uses: ./.github/actions/build-debezium-storage
+        with:
+          maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
+
+  build_schema_translator:
+    name: "Schema Translator"
+    needs: [ check_style, file_changes ]
+    runs-on: ubuntu-latest
+    if: ${{ needs.file_changes.outputs.common-changed == 'true' || needs.file_changes.outputs.schema-translator-changed == 'true' }}
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-debezium-schema-translator
         with:
           maven-cache-key: maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
 

--- a/debezium-schema-translator/README.md
+++ b/debezium-schema-translator/README.md
@@ -1,0 +1,134 @@
+# Debezium Schema Translator
+
+A lightweight HTTP service that reads PostgreSQL table schemas and registers them as Avro schemas with a Confluent Schema Registry.
+
+It leverages Debezium's PostgreSQL connector internals to extract schema information without performing any change data capture.
+
+See the [ADR](https://docs.google.com/document/d/12jFNBuNmhXG2sPwgH7Hp9410fvSrbp4UudctiEhPLS8/edit?tab=t.0#heading=h.4ocygg1bsnsl) for the full design rationale and context.
+
+## How it works
+
+For each requested table, the service:
+1. Reads the table schema from PostgreSQL using the Debezium PostgreSQL connector
+2. Converts the Kafka Connect schema to Avro format
+3. Registers both a value (envelope) schema and a key schema with the Schema Registry
+4. Returns the schema IDs and versions
+
+Subject names follow Debezium's topic naming convention:
+- Value: `{TOPIC_PREFIX}.{schema}.{table}-value`
+- Key: `{TOPIC_PREFIX}.{schema}.{table}-key`
+
+## Configuration
+
+All configuration is done via environment variables.
+
+| Variable              | Default                    | Required | Description                                          |
+|-----------------------|----------------------------|----------|------------------------------------------------------|
+| `POSTGRES_HOST`       | `localhost`                |          | PostgreSQL hostname                                  |
+| `POSTGRES_PORT`       | `5432`                     |          | PostgreSQL port                                      |
+| `POSTGRES_DATABASE`   |                            | Yes      | PostgreSQL database name                             |
+| `POSTGRES_USER`       | `postgres`                 |          | PostgreSQL user                                      |
+| `POSTGRES_PASSWORD`   |                            | Yes      | PostgreSQL password                                  |
+| `POSTGRES_SSL_MODE`   | `prefer`                   |          | SSL mode (`disable`, `prefer`, `require`, etc.)      |
+| `SCHEMA_REGISTRY_URL` | `http://localhost:8081`    |          | Confluent Schema Registry URL                        |
+| `TOPIC_PREFIX`        |                            | Yes      | Debezium topic prefix, used to derive subject names  |
+| `HTTP_PORT`           | `8080`                     |          | Port the HTTP server listens on                      |
+
+## API
+
+### Health check
+
+```
+GET /api/v1/schema-translator/health
+```
+
+```json
+{"status": "UP"}
+```
+
+### Register schemas
+
+```
+POST /api/v1/schema-translator/register-schemas
+Content-Type: application/json
+```
+
+**Request body:**
+
+```json
+{
+  "tables": ["public.users", "orders", "myschema.events"]
+}
+```
+
+Table names can be `schema.table` or just `table` (defaults to `public` schema).
+
+**Success response (200):**
+
+```json
+{
+  "registered_schemas": [
+    {
+      "table": "public.users",
+      "subject": "test.public.users-value",
+      "schema_id": 1,
+      "version": 1
+    },
+    {
+      "table": "public.users",
+      "subject": "test.public.users-key",
+      "schema_id": 2,
+      "version": 1
+    }
+  ]
+}
+```
+
+**Error responses:**
+
+| Code | Cause                                                     |
+|------|-----------------------------------------------------------|
+| 400  | Invalid request body or missing `tables` field            |
+| 405  | Wrong HTTP method                                         |
+| 409  | Schema incompatible with an already-registered version    |
+| 500  | PostgreSQL read error or Schema Registry error            |
+
+Registration is idempotent: registering an identical schema multiple times returns the same schema ID and version.
+
+## Build
+
+```bash
+mvn verify -pl debezium-schema-translator
+```
+
+This runs all tests and produces a shaded (fat) JAR at `target/debezium-schema-translator-*-shaded.jar`.
+
+Integration tests use [Testcontainers](https://testcontainers.com/) and require Docker. To skip them:
+
+```bash
+mvn verify -pl debezium-schema-translator -DskipITs
+```
+
+## Local development
+
+A `docker-compose.yml` is provided that starts PostgreSQL, Kafka, Confluent Schema Registry, and the schema translator itself.
+
+```bash
+# Build the JAR first
+mvn verify -pl debezium-schema-translator -DskipITs
+
+# Start all services
+docker-compose -f debezium-schema-translator/docker-compose.yml up -d
+
+# Check health
+curl -s http://localhost:8080/api/v1/schema-translator/health
+
+# Create a table in PostgreSQL, then register its schema
+# (replace "public.my_table" with an actual table in your database)
+curl -s -X POST http://localhost:8080/api/v1/schema-translator/register-schemas \
+  -H 'Content-Type: application/json' \
+  -d '{"tables": ["public.my_table"]}'
+
+# Inspect registered subjects in Schema Registry
+curl -s http://localhost:8081/subjects
+```

--- a/debezium-schema-translator/README.md
+++ b/debezium-schema-translator/README.md
@@ -49,7 +49,7 @@ GET /api/v1/schema-translator/health
 ### Register schemas
 
 ```
-POST /api/v1/schema-translator/register-schemas
+POST /api/v1/schema-translator/schemas
 Content-Type: application/json
 ```
 
@@ -125,7 +125,7 @@ curl -s http://localhost:8080/api/v1/schema-translator/health
 
 # Create a table in Postgres, then register its schema
 # (replace "public.my_table" with an actual table in your database)
-curl -s -X POST http://localhost:8080/api/v1/schema-translator/register-schemas \
+curl -s -X POST http://localhost:8080/api/v1/schema-translator/schemas \
   -H 'Content-Type: application/json' \
   -d '{"tables": ["public.my_table"]}'
 

--- a/debezium-schema-translator/README.md
+++ b/debezium-schema-translator/README.md
@@ -1,15 +1,15 @@
 # Debezium Schema Translator
 
-A lightweight HTTP service that reads PostgreSQL table schemas and registers them as Avro schemas with a Confluent Schema Registry.
+A lightweight HTTP service that reads Postgres table schemas and registers them as Avro schemas with a Confluent Schema Registry.
 
-It leverages Debezium's PostgreSQL connector internals to extract schema information without performing any change data capture.
+It leverages Debezium's Postgres connector internals to extract schema information without performing any change data capture.
 
 See the [ADR](https://docs.google.com/document/d/12jFNBuNmhXG2sPwgH7Hp9410fvSrbp4UudctiEhPLS8/edit?tab=t.0#heading=h.4ocygg1bsnsl) for the full design rationale and context.
 
 ## How it works
 
 For each requested table, the service:
-1. Reads the table schema from PostgreSQL using the Debezium PostgreSQL connector
+1. Reads the table schema from Postgres using the Debezium Postgres connector
 2. Converts the Kafka Connect schema to Avro format
 3. Registers both a value (envelope) schema and a key schema with the Schema Registry
 4. Returns the schema IDs and versions
@@ -24,11 +24,11 @@ All configuration is done via environment variables.
 
 | Variable              | Default                    | Required | Description                                          |
 |-----------------------|----------------------------|----------|------------------------------------------------------|
-| `POSTGRES_HOST`       | `localhost`                |          | PostgreSQL hostname                                  |
-| `POSTGRES_PORT`       | `5432`                     |          | PostgreSQL port                                      |
-| `POSTGRES_DATABASE`   |                            | Yes      | PostgreSQL database name                             |
-| `POSTGRES_USER`       | `postgres`                 |          | PostgreSQL user                                      |
-| `POSTGRES_PASSWORD`   |                            | Yes      | PostgreSQL password                                  |
+| `POSTGRES_HOST`       | `localhost`                |          | Postgres hostname                                  |
+| `POSTGRES_PORT`       | `5432`                     |          | Postgres port                                      |
+| `POSTGRES_DATABASE`   |                            | Yes      | Postgres database name                             |
+| `POSTGRES_USER`       | `postgres`                 |          | Postgres user                                      |
+| `POSTGRES_PASSWORD`   |                            | Yes      | Postgres password                                  |
 | `POSTGRES_SSL_MODE`   | `prefer`                   |          | SSL mode (`disable`, `prefer`, `require`, etc.)      |
 | `SCHEMA_REGISTRY_URL` | `http://localhost:8081`    |          | Confluent Schema Registry URL                        |
 | `TOPIC_PREFIX`        |                            | Yes      | Debezium topic prefix, used to derive subject names  |
@@ -91,7 +91,7 @@ Table names can be `schema.table` or just `table` (defaults to `public` schema).
 | 400  | Invalid request body or missing `tables` field            |
 | 405  | Wrong HTTP method                                         |
 | 409  | Schema incompatible with an already-registered version    |
-| 500  | PostgreSQL read error or Schema Registry error            |
+| 500  | Postgres read error or Schema Registry error            |
 
 Registration is idempotent: registering an identical schema multiple times returns the same schema ID and version.
 
@@ -111,7 +111,7 @@ mvn verify -pl debezium-schema-translator -DskipITs
 
 ## Local development
 
-A `docker-compose.yml` is provided that starts PostgreSQL, Kafka, Confluent Schema Registry, and the schema translator itself.
+A `docker-compose.yml` is provided that starts Postgres, Kafka, Confluent Schema Registry, and the schema translator itself.
 
 ```bash
 # Build the JAR first
@@ -123,7 +123,7 @@ docker-compose -f debezium-schema-translator/docker-compose.yml up -d
 # Check health
 curl -s http://localhost:8080/api/v1/schema-translator/health
 
-# Create a table in PostgreSQL, then register its schema
+# Create a table in Postgres, then register its schema
 # (replace "public.my_table" with an actual table in your database)
 curl -s -X POST http://localhost:8080/api/v1/schema-translator/register-schemas \
   -H 'Content-Type: application/json' \

--- a/debezium-schema-translator/docker-compose.yml
+++ b/debezium-schema-translator/docker-compose.yml
@@ -10,7 +10,7 @@ version: "3.8"
 #
 # Test:
 #   curl -s http://localhost:8080/api/v1/schema-translator/health
-#   curl -s -X POST http://localhost:8080/api/v1/schema-translator/register-schemas \
+#   curl -s -X POST http://localhost:8080/api/v1/schema-translator/schemas \
 #     -H 'Content-Type: application/json' \
 #     -d '{"tables": ["public.users"]}'
 #

--- a/debezium-schema-translator/docker-compose.yml
+++ b/debezium-schema-translator/docker-compose.yml
@@ -27,11 +27,6 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: testdb
-    command: >
-      postgres
-        -c wal_level=logical
-        -c max_replication_slots=4
-        -c max_wal_senders=4
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/debezium-schema-translator/docker-compose.yml
+++ b/debezium-schema-translator/docker-compose.yml
@@ -1,0 +1,93 @@
+version: "3.8"
+
+# Temporary docker-compose for local testing of debezium-schema-translator.
+#
+# Build the JAR first:
+#   mvn clean package -pl debezium-schema-translator -am -DskipTests
+#
+# Start everything (dependencies + schema translator):
+#   docker-compose up -d
+#
+# Test:
+#   curl -s http://localhost:8080/api/v1/schema-translator/health
+#   curl -s -X POST http://localhost:8080/api/v1/schema-translator/register-schemas \
+#     -H 'Content-Type: application/json' \
+#     -d '{"tables": ["public.users"]}'
+#
+# Inspect registered schemas:
+#   curl -s http://localhost:8081/subjects
+
+services:
+
+  postgres:
+    image: postgres:17
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: testdb
+    command: >
+      postgres
+        -c wal_level=logical
+        -c max_replication_slots=4
+        -c max_wal_senders=4
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.1
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.6.1
+    depends_on:
+      - kafka
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/subjects"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  schema-translator:
+    image: eclipse-temurin:17-jre
+    depends_on:
+      postgres:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./target:/app
+    entrypoint: ["sh", "-c", "java -jar /app/debezium-schema-translator-*-shaded.jar"]
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_DATABASE: testdb
+      POSTGRES_PASSWORD: postgres
+      TOPIC_PREFIX: test
+      SCHEMA_REGISTRY_URL: http://schema-registry:8081

--- a/debezium-schema-translator/pom.xml
+++ b/debezium-schema-translator/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-parent</artifactId>
+        <version>3.2.4.Final</version>
+        <relativePath>../debezium-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>debezium-schema-translator</artifactId>
+    <name>Debezium Schema Translator</name>
+    <description>Standalone service that reads PostgreSQL schemas and registers Avro schemas with Confluent Schema Registry</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <!-- Skip formatter and checkstyle; standalone service follows different conventions -->
+        <format.skip>true</format.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <!-- Confluent platform version — kept in sync with debezium-bom -->
+        <version.confluent.platform>7.0.16</version.confluent.platform>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <name>Confluent</name>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <!-- Debezium Postgres connector (provides PostgresConnection, TypeRegistry, PostgresValueConverter) -->
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-connector-postgres</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Debezium core (provides TableSchemaBuilder, Envelope, etc.) -->
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+        </dependency>
+
+        <!-- Kafka Connect API — compile scope (standalone app, not a KC plugin) -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Confluent Avro converter (provides AvroData.fromConnectSchema()) -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
+        </dependency>
+
+        <!-- Confluent Schema Registry client (provides CachedSchemaRegistryClient) -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+            <version>${version.confluent.platform}</version>
+        </dependency>
+
+        <!-- JSON serialization for HTTP API -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- SLF4J runtime -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <!-- SLF4J API (transitive, but explicit for clarity) -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.debezium.schematranslator.App</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.handlers</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.schemas</resource>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/debezium-schema-translator/pom.xml
+++ b/debezium-schema-translator/pom.xml
@@ -109,10 +109,48 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <forkCount>0</forkCount>
+                    <systemPropertyVariables>
+                        <!-- docker-java reads "api.version" from system properties (not "DOCKER_API_VERSION").
+                             Docker Engine 27+ dropped support for API versions below 1.44. -->
+                        <api.version>1.44</api.version>
+                        <!-- testcontainers reads "ryuk.disabled" from system properties (not "TESTCONTAINERS_RYUK_DISABLED").
+                             Disable Ryuk resource reaper to avoid pulling its image on every run. -->
+                        <ryuk.disabled>true</ryuk.disabled>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/debezium-schema-translator/pom.xml
+++ b/debezium-schema-translator/pom.xml
@@ -86,6 +86,29 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.17.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpServer;
+
+import io.debezium.schematranslator.api.HealthHandler;
+import io.debezium.schematranslator.api.RegisterSchemasHandler;
+import io.debezium.schematranslator.config.TranslatorConfig;
+import io.debezium.schematranslator.schema.AvroSchemaConverter;
+import io.debezium.schematranslator.schema.DebeziumSchemaReader;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+
+/**
+ * Main entry point for the Debezium Schema Translator service.
+ */
+public class App {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(App.class);
+
+    public static void main(String[] args) throws IOException {
+        TranslatorConfig config = new TranslatorConfig();
+
+        LOGGER.info("Starting Debezium Schema Translator on port {}", config.getHttpPort());
+
+        // Initialise core components
+        DebeziumSchemaReader schemaReader = new DebeziumSchemaReader(config.toDebeziumConfig());
+        AvroSchemaConverter avroConverter = new AvroSchemaConverter();
+        SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(config.getSchemaRegistryUrl());
+
+        // Register shutdown hook to close JDBC connection cleanly
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOGGER.info("Shutting down...");
+            try {
+                schemaReader.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error during shutdown", e);
+            }
+        }));
+
+        // Start HTTP server
+        HttpServer server = HttpServer.create(new InetSocketAddress(config.getHttpPort()), 0);
+        server.createContext(
+                "/api/v1/schema-translator/register-schemas",
+                new RegisterSchemasHandler(schemaReader, avroConverter, publisher));
+        server.createContext(
+                "/api/v1/schema-translator/health",
+                new HealthHandler());
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+
+        LOGGER.info("Debezium Schema Translator is running on port {}", config.getHttpPort());
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
@@ -1,25 +1,18 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.concurrent.Executors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sun.net.httpserver.HttpServer;
-
 import io.debezium.schematranslator.api.HealthHandler;
 import io.debezium.schematranslator.api.RegisterSchemasHandler;
 import io.debezium.schematranslator.config.TranslatorConfig;
 import io.debezium.schematranslator.schema.AvroSchemaConverter;
 import io.debezium.schematranslator.schema.DebeziumSchemaReader;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Executors;
 
 /**
  * Main entry point for the Debezium Schema Translator service.

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
@@ -52,7 +52,7 @@ public class App {
         // Start HTTP server
         HttpServer server = HttpServer.create(new InetSocketAddress(config.getHttpPort()), 0);
         server.createContext(
-                "/api/v1/schema-translator/register-schemas",
+                "/api/v1/schema-translator/schemas",
                 new RegisterSchemasHandler(schemaReader, avroConverter, publisher));
         server.createContext(
                 "/api/v1/schema-translator/health",

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
@@ -31,17 +31,6 @@ public class App {
         AvroSchemaConverter avroConverter = new AvroSchemaConverter();
         SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(config.getSchemaRegistryUrl());
 
-        // Register shutdown hook to close JDBC connection cleanly
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            LOGGER.info("Shutting down...");
-            try {
-                schemaReader.close();
-            }
-            catch (Exception e) {
-                LOGGER.warn("Error during shutdown", e);
-            }
-        }));
-
         // Start HTTP server
         HttpServer server = HttpServer.create(new InetSocketAddress(config.getHttpPort()), 0);
         server.createContext(
@@ -54,5 +43,17 @@ public class App {
         server.start();
 
         LOGGER.info("Debezium Schema Translator is running on port {}", config.getHttpPort());
+
+        // Register shutdown hook to stop the HTTP server and close the JDBC connection cleanly
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOGGER.info("Shutting down...");
+            server.stop(0);
+            try {
+                schemaReader.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error during shutdown", e);
+            }
+        }));
     }
 }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/HealthHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/HealthHandler.java
@@ -1,16 +1,11 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
 
 /**
  * Handles GET /api/v1/schema-translator/health.

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/HealthHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/HealthHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.api;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+/**
+ * Handles GET /api/v1/schema-translator/health.
+ * Returns {"status": "UP"} with HTTP 200.
+ */
+public class HealthHandler implements HttpHandler {
+
+    private static final byte[] BODY = "{\"status\":\"UP\"}".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, BODY.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(BODY);
+        }
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/HealthHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/HealthHandler.java
@@ -17,6 +17,10 @@ public class HealthHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
         exchange.getResponseHeaders().set("Content-Type", "application/json");
         exchange.sendResponseHeaders(200, BODY.length);
         try (OutputStream out = exchange.getResponseBody()) {

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+import io.debezium.schematranslator.model.ErrorResponse;
+import io.debezium.schematranslator.model.RegisteredSchema;
+import io.debezium.schematranslator.model.SchemaRegistrationRequest;
+import io.debezium.schematranslator.model.SchemaRegistrationResponse;
+import io.debezium.schematranslator.schema.AvroSchemaConverter;
+import io.debezium.schematranslator.schema.DebeziumSchemaReader;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
+
+/**
+ * Handles POST /api/v1/schema-translator/register-schemas.
+ */
+public class RegisterSchemasHandler implements HttpHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegisterSchemasHandler.class);
+
+    private final ObjectMapper objectMapper;
+    private final DebeziumSchemaReader schemaReader;
+    private final AvroSchemaConverter avroConverter;
+    private final SchemaRegistryPublisher publisher;
+
+    public RegisterSchemasHandler(DebeziumSchemaReader schemaReader,
+                                  AvroSchemaConverter avroConverter,
+                                  SchemaRegistryPublisher publisher) {
+        this.objectMapper = new ObjectMapper();
+        this.schemaReader = schemaReader;
+        this.avroConverter = avroConverter;
+        this.publisher = publisher;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+            sendJson(exchange, 405, new ErrorResponse("Method not allowed"));
+            return;
+        }
+
+        // Parse request body
+        SchemaRegistrationRequest request;
+        try (InputStream body = exchange.getRequestBody()) {
+            request = objectMapper.readValue(body, SchemaRegistrationRequest.class);
+        }
+        catch (Exception e) {
+            sendJson(exchange, 400, new ErrorResponse("Invalid JSON request body: " + e.getMessage()));
+            return;
+        }
+
+        // Validate tables field
+        if (request.getTables() == null || request.getTables().isEmpty()) {
+            sendJson(exchange, 400,
+                    new ErrorResponse("Field 'tables' is required and must contain at least one entry"));
+            return;
+        }
+
+        List<String> tables = request.getTables();
+        LOGGER.info("Processing register-schemas request for {} table(s): {}", tables.size(), tables);
+
+        // Read schemas from PostgreSQL
+        Map<TableId, TableSchema> tableSchemas;
+        try {
+            tableSchemas = schemaReader.readSchemas(tables);
+        }
+        catch (Exception e) {
+            LOGGER.error("Failed to read schemas from PostgreSQL", e);
+            sendJson(exchange, 500, new ErrorResponse(e.getMessage()));
+            return;
+        }
+
+        // Register each schema with Schema Registry
+        List<RegisteredSchema> results = new ArrayList<>();
+        int tableIndex = 0;
+        for (Map.Entry<TableId, TableSchema> entry : tableSchemas.entrySet()) {
+            TableId tableId = entry.getKey();
+            TableSchema tableSchema = entry.getValue();
+            String originalTableName = tables.get(tableIndex++);
+
+            // Derive subject from topic name
+            String topic = schemaReader.getTopicNamingStrategy().dataChangeTopic(tableId);
+            String subject = topic + "-value";
+
+            // Convert envelope schema from Connect to Avro
+            org.apache.kafka.connect.data.Schema envelopeConnectSchema = tableSchema.getEnvelopeSchema().schema();
+            org.apache.avro.Schema avroSchema = avroConverter.toAvro(envelopeConnectSchema);
+
+            // Register in Schema Registry
+            try {
+                RegisteredSchema registered = publisher.register(originalTableName, subject, avroSchema);
+                results.add(registered);
+            }
+            catch (SchemaIncompatibilityException e) {
+                LOGGER.warn("Schema incompatibility for table '{}': {}", originalTableName, e.getMessage());
+                sendJson(exchange, 409, new ErrorResponse(e.getMessage()));
+                return;
+            }
+            catch (IOException e) {
+                LOGGER.error("Failed to register schema for table '{}'", originalTableName, e);
+                sendJson(exchange, 500, new ErrorResponse(
+                        "Failed to register schema for table " + originalTableName + ": " + e.getMessage()));
+                return;
+            }
+        }
+
+        sendJson(exchange, 200, new SchemaRegistrationResponse(results));
+    }
+
+    private void sendJson(HttpExchange exchange, int statusCode, Object body) throws IOException {
+        byte[] responseBytes = objectMapper.writeValueAsBytes(body);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, responseBytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(responseBytes);
+        }
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -1,25 +1,8 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.api;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.schematranslator.model.ErrorResponse;
@@ -30,6 +13,15 @@ import io.debezium.schematranslator.schema.AvroSchemaConverter;
 import io.debezium.schematranslator.schema.DebeziumSchemaReader;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Handles POST /api/v1/schema-translator/register-schemas.
@@ -79,13 +71,13 @@ public class RegisterSchemasHandler implements HttpHandler {
         List<String> tables = request.getTables();
         LOGGER.info("Processing register-schemas request for {} table(s): {}", tables.size(), tables);
 
-        // Read schemas from PostgreSQL
+        // Read schemas from Postgres
         Map<TableId, TableSchema> tableSchemas;
         try {
             tableSchemas = schemaReader.readSchemas(tables);
         }
         catch (Exception e) {
-            LOGGER.error("Failed to read schemas from PostgreSQL", e);
+            LOGGER.error("Failed to read schemas from Postgres", e);
             sendJson(exchange, 500, new ErrorResponse(e.getMessage()));
             return;
         }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -84,6 +84,7 @@ public class RegisterSchemasHandler implements HttpHandler {
 
         // Register each schema with Schema Registry
         List<RegisteredSchema> results = new ArrayList<>();
+        List<String> incompatibilityErrors = new ArrayList<>();
         int tableIndex = 0;
         for (Map.Entry<TableId, TableSchema> entry : tableSchemas.entrySet()) {
             TableId tableId = entry.getKey();
@@ -111,8 +112,7 @@ public class RegisterSchemasHandler implements HttpHandler {
             }
             catch (SchemaIncompatibilityException e) {
                 LOGGER.warn("Schema incompatibility for table '{}': {}", originalTableName, e.getMessage());
-                sendJson(exchange, 409, new ErrorResponse(e.getMessage()));
-                return;
+                incompatibilityErrors.add(e.getMessage());
             }
             catch (IOException e) {
                 LOGGER.error("Failed to register schema for table '{}'", originalTableName, e);
@@ -120,6 +120,12 @@ public class RegisterSchemasHandler implements HttpHandler {
                         "Failed to register schema for table " + originalTableName + ": " + e.getMessage()));
                 return;
             }
+        }
+
+        if (!incompatibilityErrors.isEmpty()) {
+            sendJson(exchange, 409, new ErrorResponse("One or more schemas are incompatible with an existing version",
+                    incompatibilityErrors));
+            return;
         }
 
         sendJson(exchange, 200, new SchemaRegistrationResponse(results));

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Handles POST /api/v1/schema-translator/register-schemas.
+ * Handles POST /api/v1/schema-translator/schemas.
  */
 public class RegisterSchemasHandler implements HttpHandler {
 
@@ -69,7 +69,7 @@ public class RegisterSchemasHandler implements HttpHandler {
         }
 
         List<String> tables = request.getTables();
-        LOGGER.info("Processing register-schemas request for {} table(s): {}", tables.size(), tables);
+        LOGGER.info("Processing schemas request for {} table(s): {}", tables.size(), tables);
 
         // Read schemas from Postgres
         Map<TableId, TableSchema> tableSchemas;

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -98,18 +98,24 @@ public class RegisterSchemasHandler implements HttpHandler {
             TableSchema tableSchema = entry.getValue();
             String originalTableName = tables.get(tableIndex++);
 
-            // Derive subject from topic name
+            // Derive subjects from topic name
             String topic = schemaReader.getTopicNamingStrategy().dataChangeTopic(tableId);
-            String subject = topic + "-value";
+            String valueSubject = topic + "-value";
+            String keySubject = topic + "-key";
 
-            // Convert envelope schema from Connect to Avro
+            // Convert schemas from Connect to Avro
             org.apache.kafka.connect.data.Schema envelopeConnectSchema = tableSchema.getEnvelopeSchema().schema();
-            org.apache.avro.Schema avroSchema = avroConverter.toAvro(envelopeConnectSchema);
+            org.apache.avro.Schema valueAvroSchema = avroConverter.toAvro(envelopeConnectSchema);
 
-            // Register in Schema Registry
+            org.apache.kafka.connect.data.Schema keyConnectSchema = tableSchema.keySchema();
+
+            // Register value schema (envelope) and, when a primary key exists, key schema
             try {
-                RegisteredSchema registered = publisher.register(originalTableName, subject, avroSchema);
-                results.add(registered);
+                results.add(publisher.register(originalTableName, valueSubject, valueAvroSchema));
+                if (keyConnectSchema != null) {
+                    org.apache.avro.Schema keyAvroSchema = avroConverter.toAvro(keyConnectSchema);
+                    results.add(publisher.register(originalTableName, keySubject, keyAvroSchema));
+                }
             }
             catch (SchemaIncompatibilityException e) {
                 LOGGER.warn("Schema incompatibility for table '{}': {}", originalTableName, e.getMessage());

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/config/TranslatorConfig.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/config/TranslatorConfig.java
@@ -1,23 +1,18 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.config;
+
+import io.debezium.config.Configuration;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import io.debezium.config.Configuration;
-
 /**
  * Configuration loaded from environment variables.
- * Provides independent config groups for PostgreSQL and Schema Registry.
+ * Provides independent config groups for Postgres and Schema Registry.
  */
 public class TranslatorConfig {
 
-    // PostgreSQL connection settings
+    // Postgres connection settings
     private final String postgresHost;
     private final int postgresPort;
     private final String postgresDatabase;
@@ -47,7 +42,7 @@ public class TranslatorConfig {
     }
 
     /**
-     * Builds the Debezium {@link Configuration} for the PostgreSQL connector side.
+     * Builds the Debezium {@link Configuration} for the Postgres connector side.
      */
     public Configuration toDebeziumConfig() {
         Properties props = new Properties();

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/config/TranslatorConfig.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/config/TranslatorConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import io.debezium.config.Configuration;
+
+/**
+ * Configuration loaded from environment variables.
+ * Provides independent config groups for PostgreSQL and Schema Registry.
+ */
+public class TranslatorConfig {
+
+    // PostgreSQL connection settings
+    private final String postgresHost;
+    private final int postgresPort;
+    private final String postgresDatabase;
+    private final String postgresUser;
+    private final String postgresPassword;
+    private final String postgresSslMode;
+
+    // Schema Registry settings
+    private final String schemaRegistryUrl;
+
+    // Service settings
+    private final String topicPrefix;
+    private final int httpPort;
+
+    public TranslatorConfig() {
+        this.postgresHost = getEnv("POSTGRES_HOST", "localhost");
+        this.postgresPort = Integer.parseInt(getEnv("POSTGRES_PORT", "5432"));
+        this.postgresDatabase = requireEnv("POSTGRES_DATABASE");
+        this.postgresUser = getEnv("POSTGRES_USER", "postgres");
+        this.postgresPassword = requireEnv("POSTGRES_PASSWORD");
+        this.postgresSslMode = getEnv("POSTGRES_SSL_MODE", "prefer");
+
+        this.schemaRegistryUrl = getEnv("SCHEMA_REGISTRY_URL", "http://localhost:8081");
+
+        this.topicPrefix = requireEnv("TOPIC_PREFIX");
+        this.httpPort = Integer.parseInt(getEnv("HTTP_PORT", "8080"));
+    }
+
+    /**
+     * Builds the Debezium {@link Configuration} for the PostgreSQL connector side.
+     */
+    public Configuration toDebeziumConfig() {
+        Properties props = new Properties();
+        props.put("database.hostname", postgresHost);
+        props.put("database.port", String.valueOf(postgresPort));
+        props.put("database.dbname", postgresDatabase);
+        props.put("database.user", postgresUser);
+        props.put("database.password", postgresPassword);
+        props.put("database.sslmode", postgresSslMode);
+        props.put("topic.prefix", topicPrefix);
+        // Required for Avro-compatible schema names
+        props.put("schema.name.adjustment.mode", "avro");
+        // Required by config validation, never used at runtime
+        props.put("plugin.name", "pgoutput");
+        props.put("slot.name", "dummy_slot");
+        return Configuration.from(props);
+    }
+
+    /**
+     * Builds the Schema Registry client configuration map.
+     */
+    public Map<String, String> toSchemaRegistryConfig() {
+        Map<String, String> srProps = new HashMap<>();
+        srProps.put("schema.registry.url", schemaRegistryUrl);
+        return srProps;
+    }
+
+    public String getSchemaRegistryUrl() {
+        return schemaRegistryUrl;
+    }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public String getTopicPrefix() {
+        return topicPrefix;
+    }
+
+    private static String getEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return (value != null && !value.isBlank()) ? value : defaultValue;
+    }
+
+    private static String requireEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Required environment variable '" + name + "' is not set");
+        }
+        return value;
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error response body.
+ */
+public class ErrorResponse {
+
+    @JsonProperty("error")
+    private String error;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(String error) {
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
@@ -1,27 +1,55 @@
 package io.debezium.schematranslator.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 /**
- * Error response body.
+ * Error response body following Google API style:
+ * {@code {"error": {"message": "...", "errors": [...]}}}
+ *
+ * <p>{@code errors} is omitted when there is only a single error (e.g. 400, 405, 500).
+ * It is populated for 409 schema-incompatibility responses so all failing tables
+ * are reported in one round-trip.
  */
 public class ErrorResponse {
 
     @JsonProperty("error")
-    private String error;
+    private final ErrorDetail error;
 
-    public ErrorResponse() {
+    public ErrorResponse(String message) {
+        this.error = new ErrorDetail(message, null);
     }
 
-    public ErrorResponse(String error) {
-        this.error = error;
+    public ErrorResponse(String message, List<String> errors) {
+        this.error = new ErrorDetail(message, errors);
     }
 
-    public String getError() {
+    public ErrorDetail getError() {
         return error;
     }
 
-    public void setError(String error) {
-        this.error = error;
+    public static class ErrorDetail {
+
+        @JsonProperty("message")
+        private final String message;
+
+        @JsonProperty("errors")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private final List<String> errors;
+
+        public ErrorDetail(String message, List<String> errors) {
+            this.message = message;
+            this.errors = errors;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public List<String> getErrors() {
+            return errors;
+        }
     }
 }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/RegisteredSchema.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/RegisteredSchema.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Per-table registration result.
+ */
+public class RegisteredSchema {
+
+    @JsonProperty("table")
+    private String table;
+
+    @JsonProperty("subject")
+    private String subject;
+
+    @JsonProperty("schema_id")
+    private int schemaId;
+
+    @JsonProperty("version")
+    private int version;
+
+    public RegisteredSchema() {
+    }
+
+    public RegisteredSchema(String table, String subject, int schemaId, int version) {
+        this.table = table;
+        this.subject = subject;
+        this.schemaId = schemaId;
+        this.version = version;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public int getSchemaId() {
+        return schemaId;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/RegisteredSchema.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/RegisteredSchema.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
@@ -1,13 +1,8 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.model;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 
 /**
  * Request body for POST /api/v1/schema-translator/register-schemas.

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request body for POST /api/v1/schema-translator/register-schemas.
+ */
+public class SchemaRegistrationRequest {
+
+    @JsonProperty("tables")
+    private List<String> tables;
+
+    public SchemaRegistrationRequest() {
+    }
+
+    public List<String> getTables() {
+        return tables;
+    }
+
+    public void setTables(List<String> tables) {
+        this.tables = tables;
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
- * Request body for POST /api/v1/schema-translator/register-schemas.
+ * Request body for POST /api/v1/schema-translator/schemas.
  */
 public class SchemaRegistrationRequest {
 

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationResponse.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
- * Response body for a successful POST /api/v1/schema-translator/register-schemas.
+ * Response body for a successful POST /api/v1/schema-translator/schemas.
  */
 public class SchemaRegistrationResponse {
 

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response body for a successful POST /api/v1/schema-translator/register-schemas.
+ */
+public class SchemaRegistrationResponse {
+
+    @JsonProperty("registered_schemas")
+    private List<RegisteredSchema> registeredSchemas;
+
+    public SchemaRegistrationResponse() {
+    }
+
+    public SchemaRegistrationResponse(List<RegisteredSchema> registeredSchemas) {
+        this.registeredSchemas = registeredSchemas;
+    }
+
+    public List<RegisteredSchema> getRegisteredSchemas() {
+        return registeredSchemas;
+    }
+
+    public void setRegisteredSchemas(List<RegisteredSchema> registeredSchemas) {
+        this.registeredSchemas = registeredSchemas;
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationResponse.java
@@ -1,13 +1,8 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.model;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 
 /**
  * Response body for a successful POST /api/v1/schema-translator/register-schemas.

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaConverter.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.schema;
+
+import io.confluent.connect.avro.AvroData;
+
+/**
+ * Converts Kafka Connect {@link org.apache.kafka.connect.data.Schema} objects to
+ * Apache Avro {@link org.apache.avro.Schema} using Confluent's {@link AvroData}.
+ */
+public class AvroSchemaConverter {
+
+    private final AvroData avroData;
+
+    public AvroSchemaConverter() {
+        // Cache size of 1000 schema conversions
+        this.avroData = new AvroData(1000);
+    }
+
+    /**
+     * Converts a Kafka Connect schema to an Avro schema.
+     */
+    public org.apache.avro.Schema toAvro(org.apache.kafka.connect.data.Schema connectSchema) {
+        return avroData.fromConnectSchema(connectSchema);
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaConverter.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaConverter.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.schema;
 
 import io.confluent.connect.avro.AvroData;

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.schema;
+
+import java.nio.charset.Charset;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresValueConverter;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.PostgresConnection.PostgresValueConverterBuilder;
+import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;
+import io.debezium.relational.CustomConverterRegistry;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+import io.debezium.relational.TableSchemaBuilder;
+import io.debezium.relational.Tables;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.topic.TopicNamingStrategy;
+
+/**
+ * Reads PostgreSQL table schemas using Debezium's postgres connector machinery.
+ * Mirrors the initialization from {@code PostgresConnectorTask.start()} but strips out
+ * everything CDC-related — no replication slots, no streaming, no snapshotter.
+ *
+ * The PostgreSQL connection is initialized lazily on the first call to {@link #readSchemas},
+ * so the service can start without PostgreSQL being available. The connection is then
+ * reused for subsequent calls.
+ */
+public class DebeziumSchemaReader implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumSchemaReader.class);
+
+    private final PostgresConnectorConfig connectorConfig;
+    private final TopicNamingStrategy<TableId> topicNamingStrategy;
+
+    // Lazily initialized on first readSchemas() call, then reused
+    private volatile PostgresConnection pgConnection;
+    private volatile TableSchemaBuilder tableSchemaBuilder;
+
+    @SuppressWarnings("unchecked")
+    public DebeziumSchemaReader(Configuration config) {
+        this.connectorConfig = new PostgresConnectorConfig(config);
+        this.topicNamingStrategy = connectorConfig.getTopicNamingStrategy(
+                PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
+    }
+
+    /**
+     * Reads the Kafka Connect schemas for the specified tables.
+     *
+     * @param tableNames list of table names in "schema.table" or "table" format
+     * @return ordered map from TableId to TableSchema
+     * @throws RuntimeException if a table is not found or a database error occurs
+     */
+    public Map<TableId, TableSchema> readSchemas(List<String> tableNames) throws SQLException {
+        ensureConnected();
+
+        // Parse table names, defaulting schema to "public" when not specified
+        // (mirrors PostgresSchema.parse() which is protected)
+        List<TableId> requestedIds = tableNames.stream()
+                .map(DebeziumSchemaReader::parseTableId)
+                .collect(Collectors.toList());
+
+        Set<TableId> requestedSet = Set.copyOf(requestedIds);
+        Tables.TableFilter filter = Tables.TableFilter.fromPredicate(requestedSet::contains);
+
+        // Read schema metadata from JDBC
+        Tables tables = new Tables();
+        pgConnection.readSchema(tables, null, null, filter, null, true);
+
+        Map<TableId, TableSchema> result = new LinkedHashMap<>();
+        for (TableId tableId : requestedIds) {
+            Table table = tables.forTable(tableId);
+            if (table == null) {
+                throw new RuntimeException("Table not found: " + tableId);
+            }
+            TableSchema tableSchema = tableSchemaBuilder.create(
+                    topicNamingStrategy, table, null, null, null);
+            result.put(tableId, tableSchema);
+        }
+        return result;
+    }
+
+    /**
+     * Initializes the PostgreSQL connection and related components on the first call.
+     * Subsequent calls are no-ops if the connection is already established.
+     * Uses double-checked locking to avoid redundant initialization under concurrency.
+     */
+    private void ensureConnected() {
+        if (pgConnection != null) {
+            return;
+        }
+        synchronized (this) {
+            if (pgConnection != null) {
+                return;
+            }
+            LOGGER.info("Initializing PostgreSQL connection");
+            initConnection();
+        }
+    }
+
+    private void initConnection() {
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
+
+        // Step 1: Get database charset (same pattern as PostgresConnectorTask line 109)
+        final Charset databaseCharset;
+        try (PostgresConnection temp = new PostgresConnection(
+                connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
+            databaseCharset = temp.getDatabaseCharset();
+        }
+
+        // Step 2: Build value converter builder
+        final PostgresValueConverterBuilder vcBuilder = (typeRegistry) -> PostgresValueConverter.of(
+                connectorConfig, databaseCharset, typeRegistry);
+
+        // Step 3: Create main connection (initialises TypeRegistry internally)
+        final PostgresConnection connection = new PostgresConnection(
+                connectorConfig.getJdbcConfig(), vcBuilder, PostgresConnection.CONNECTION_GENERAL);
+
+        // Step 4: Extract components
+        final PostgresDefaultValueConverter defaultValueConverter = connection.getDefaultValueConverter();
+        final PostgresValueConverter valueConverter = vcBuilder.build(connection.getTypeRegistry());
+
+        // Step 5: Build TableSchemaBuilder (mirrors PostgresSchema.getTableSchemaBuilder())
+        final Schema sourceInfoSchema = connectorConfig.getSourceInfoStructMaker().schema();
+        final CustomConverterRegistry customConverterRegistry = new CustomConverterRegistry(null);
+        this.tableSchemaBuilder = new TableSchemaBuilder(
+                valueConverter, defaultValueConverter, schemaNameAdjuster,
+                customConverterRegistry, sourceInfoSchema,
+                connectorConfig.getFieldNamer(), false);
+
+        // Assign last so that pgConnection != null only once fully initialized
+        this.pgConnection = connection;
+        LOGGER.info("PostgreSQL connection initialized successfully");
+    }
+
+    /**
+     * Parses a table name string into a {@link TableId}, defaulting the schema to {@code "public"}
+     * when no schema is specified. Mirrors the logic of {@code PostgresSchema.parse()}.
+     */
+    private static TableId parseTableId(String table) {
+        TableId tableId = TableId.parse(table, false);
+        if (tableId == null) {
+            throw new IllegalArgumentException("Invalid table name: " + table);
+        }
+        return tableId.schema() == null
+                ? new TableId(tableId.catalog(), "public", tableId.table())
+                : tableId;
+    }
+
+    /**
+     * Returns the topic naming strategy, used to derive subjects for SR registration.
+     */
+    public TopicNamingStrategy<TableId> getTopicNamingStrategy() {
+        return topicNamingStrategy;
+    }
+
+    @Override
+    public void close() {
+        synchronized (this) {
+            if (pgConnection != null) {
+                try {
+                    pgConnection.close();
+                }
+                catch (Exception e) {
+                    LOGGER.warn("Error closing PostgresConnection", e);
+                }
+                pgConnection = null;
+                tableSchemaBuilder = null;
+            }
+        }
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
@@ -1,21 +1,4 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.schema;
-
-import java.nio.charset.Charset;
-import java.sql.SQLException;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.apache.kafka.connect.data.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -31,14 +14,24 @@ import io.debezium.relational.TableSchemaBuilder;
 import io.debezium.relational.Tables;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
+import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
- * Reads PostgreSQL table schemas using Debezium's postgres connector machinery.
+ * Reads Postgres table schemas using Debezium's postgres connector machinery.
  * Mirrors the initialization from {@code PostgresConnectorTask.start()} but strips out
  * everything CDC-related — no replication slots, no streaming, no snapshotter.
- *
- * The PostgreSQL connection is initialized lazily on the first call to {@link #readSchemas},
- * so the service can start without PostgreSQL being available. The connection is then
+ * <p>
+ * The Postgres connection is initialized lazily on the first call to {@link #readSchemas},
+ * so the service can start without Postgres being available. The connection is then
  * reused for subsequent calls.
  */
 public class DebeziumSchemaReader implements AutoCloseable {
@@ -73,7 +66,7 @@ public class DebeziumSchemaReader implements AutoCloseable {
         // (mirrors PostgresSchema.parse() which is protected)
         List<TableId> requestedIds = tableNames.stream()
                 .map(DebeziumSchemaReader::parseTableId)
-                .collect(Collectors.toList());
+                .toList();
 
         Set<TableId> requestedSet = Set.copyOf(requestedIds);
         Tables.TableFilter filter = Tables.TableFilter.fromPredicate(requestedSet::contains);
@@ -96,7 +89,7 @@ public class DebeziumSchemaReader implements AutoCloseable {
     }
 
     /**
-     * Initializes the PostgreSQL connection and related components on the first call.
+     * Initializes the Postgres connection and related components on the first call.
      * Subsequent calls are no-ops if the connection is already established.
      * Uses double-checked locking to avoid redundant initialization under concurrency.
      */
@@ -108,7 +101,7 @@ public class DebeziumSchemaReader implements AutoCloseable {
             if (pgConnection != null) {
                 return;
             }
-            LOGGER.info("Initializing PostgreSQL connection");
+            LOGGER.info("Initializing Postgres connection");
             initConnection();
         }
     }
@@ -116,26 +109,21 @@ public class DebeziumSchemaReader implements AutoCloseable {
     private void initConnection() {
         final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
 
-        // Step 1: Get database charset (same pattern as PostgresConnectorTask line 109)
         final Charset databaseCharset;
         try (PostgresConnection temp = new PostgresConnection(
                 connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
             databaseCharset = temp.getDatabaseCharset();
         }
 
-        // Step 2: Build value converter builder
         final PostgresValueConverterBuilder vcBuilder = (typeRegistry) -> PostgresValueConverter.of(
                 connectorConfig, databaseCharset, typeRegistry);
 
-        // Step 3: Create main connection (initialises TypeRegistry internally)
         final PostgresConnection connection = new PostgresConnection(
                 connectorConfig.getJdbcConfig(), vcBuilder, PostgresConnection.CONNECTION_GENERAL);
 
-        // Step 4: Extract components
         final PostgresDefaultValueConverter defaultValueConverter = connection.getDefaultValueConverter();
         final PostgresValueConverter valueConverter = vcBuilder.build(connection.getTypeRegistry());
 
-        // Step 5: Build TableSchemaBuilder (mirrors PostgresSchema.getTableSchemaBuilder())
         final Schema sourceInfoSchema = connectorConfig.getSourceInfoStructMaker().schema();
         final CustomConverterRegistry customConverterRegistry = new CustomConverterRegistry(null);
         this.tableSchemaBuilder = new TableSchemaBuilder(
@@ -143,9 +131,8 @@ public class DebeziumSchemaReader implements AutoCloseable {
                 customConverterRegistry, sourceInfoSchema,
                 connectorConfig.getFieldNamer(), false);
 
-        // Assign last so that pgConnection != null only once fully initialized
         this.pgConnection = connection;
-        LOGGER.info("PostgreSQL connection initialized successfully");
+        LOGGER.info("Postgres connection initialized successfully");
     }
 
     /**

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.schema;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.debezium.schematranslator.model.RegisteredSchema;
+
+/**
+ * Registers Avro schemas with the Confluent Schema Registry.
+ */
+public class SchemaRegistryPublisher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegistryPublisher.class);
+
+    private final SchemaRegistryClient client;
+
+    public SchemaRegistryPublisher(String schemaRegistryUrl) {
+        this.client = new CachedSchemaRegistryClient(
+                Collections.singletonList(schemaRegistryUrl), 1000);
+    }
+
+    /**
+     * Registers the given Avro schema under the given subject.
+     *
+     * @param tableName the original table name string (for reporting)
+     * @param subject   the SR subject (e.g. "prefix.public.users-value")
+     * @param avroSchema the Avro schema to register
+     * @return the registered schema result with schema_id and version
+     * @throws SchemaIncompatibilityException if the schema is incompatible with an existing one (HTTP 409)
+     * @throws IOException                    if a network or infrastructure error occurs
+     */
+    public RegisteredSchema register(String tableName, String subject, Schema avroSchema)
+            throws SchemaIncompatibilityException, IOException {
+        LOGGER.info("Registering schema for subject '{}' (table '{}')", subject, tableName);
+        try {
+            int schemaId = client.register(subject, new AvroSchema(avroSchema));
+            SchemaMetadata metadata = client.getLatestSchemaMetadata(subject);
+            int version = metadata.getVersion();
+            LOGGER.info("Registered subject '{}': schema_id={}, version={}", subject, schemaId, version);
+            return new RegisteredSchema(tableName, subject, schemaId, version);
+        }
+        catch (RestClientException e) {
+            if (e.getStatus() == 409) {
+                throw new SchemaIncompatibilityException(
+                        "Schema for table " + tableName + " is incompatible with an earlier schema for subject \""
+                                + subject + "\": " + e.getMessage(),
+                        e);
+            }
+            throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Thrown when a 409 Conflict is returned by the Schema Registry.
+     */
+    public static class SchemaIncompatibilityException extends Exception {
+        public SchemaIncompatibilityException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -1,17 +1,4 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.schema;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-
-import org.apache.avro.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
@@ -19,6 +6,12 @@ import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.debezium.schematranslator.model.RegisteredSchema;
+import org.apache.avro.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Registers Avro schemas with the Confluent Schema Registry.

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -99,7 +99,7 @@ class RegisterSchemasHandlerIT {
         RegisterSchemasHandler handler = new RegisterSchemasHandler(reader, new AvroSchemaConverter(), publisher);
 
         handlerServer = HttpServer.create(new InetSocketAddress(0), 0);
-        handlerServer.createContext("/api/v1/schema-translator/register-schemas", handler);
+        handlerServer.createContext("/api/v1/schema-translator/schemas", handler);
         handlerServer.start();
         handlerPort = handlerServer.getAddress().getPort();
     }
@@ -219,7 +219,7 @@ class RegisterSchemasHandlerIT {
 
     private HttpURLConnection post(String jsonBody) throws Exception {
         URL url = new URL("http://localhost:" + handlerPort
-                + "/api/v1/schema-translator/register-schemas");
+                + "/api/v1/schema-translator/schemas");
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("POST");
         conn.setRequestProperty("Content-Type", "application/json");

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -1,22 +1,10 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
-import java.time.Duration;
-import java.util.Properties;
-
+import com.sun.net.httpserver.HttpServer;
+import io.debezium.config.Configuration;
+import io.debezium.schematranslator.schema.AvroSchemaConverter;
+import io.debezium.schematranslator.schema.DebeziumSchemaReader;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,31 +17,26 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-import com.sun.net.httpserver.HttpServer;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
 
-import io.debezium.config.Configuration;
-import io.debezium.schematranslator.schema.AvroSchemaConverter;
-import io.debezium.schematranslator.schema.DebeziumSchemaReader;
-import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test for {@link RegisterSchemasHandler}.
- * <p>
- * Exercises the full registration pipeline:
- * HTTP request → handler → PostgreSQL (Testcontainers) → Avro conversion
- * → real Confluent Schema Registry (Testcontainers) → HTTP response.
- * <p>
- * All three containers share a Docker network so Schema Registry can reach
- * Kafka's internal broker listener. A fresh component chain is created per
- * test to prevent Confluent client cache carryover between tests.
+ * Components are recreated per test to avoid Confluent client cache carryover between tests.
  */
 @Testcontainers
 class RegisterSchemasHandlerIT {
 
-    // -------------------------------------------------------------------------
-    // Shared Docker network and containers (started once for the test class)
-    // -------------------------------------------------------------------------
-
+    // Shared network so Schema Registry can reach Kafka's internal broker listener
     private static final Network network = Network.newNetwork();
 
     @Container
@@ -83,10 +66,6 @@ class RegisterSchemasHandlerIT {
                     .forStatusCode(200)
                     .withStartupTimeout(Duration.ofSeconds(30)));
 
-    // -------------------------------------------------------------------------
-    // Per-test handler server (recreated to avoid Confluent client cache carryover)
-    // -------------------------------------------------------------------------
-
     private HttpServer handlerServer;
     private int handlerPort;
     private DebeziumSchemaReader reader;
@@ -110,10 +89,6 @@ class RegisterSchemasHandlerIT {
         reader.close();
     }
 
-    // -------------------------------------------------------------------------
-    // Tests
-    // -------------------------------------------------------------------------
-
     @Test
     void registersSchemaEndToEnd() throws Exception {
         execute("CREATE TABLE IF NOT EXISTS public.products (" +
@@ -128,7 +103,7 @@ class RegisterSchemasHandlerIT {
         assertThat(conn.getResponseCode()).isEqualTo(200);
         assertThat(body).contains("\"subject\":\"test.public.products-value\"");
         assertThat(body).contains("\"subject\":\"test.public.products-key\"");
-        assertThat(body.split("\"table\":\"public.products\"", -1)).hasSize(3); // 2 occurrences → 3 parts
+        assertThat(body.split("\"table\":\"public.products\"", -1)).hasSize(3);
     }
 
     /**
@@ -147,15 +122,12 @@ class RegisterSchemasHandlerIT {
                 "  name TEXT NOT NULL" +
                 ")");
 
-        // First registration: value and key schemas at version 1
         HttpURLConnection conn1 = post("{\"tables\":[\"public.evolution_ok\"]}");
         assertThat(conn1.getResponseCode()).isEqualTo(200);
         conn1.getInputStream().readAllBytes(); // drain
 
-        // Evolve the table: nullable column → backward-compatible Avro optional field
         execute("ALTER TABLE public.evolution_ok ADD COLUMN notes TEXT");
 
-        // Second registration: value schema has a new optional field → version 2
         HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_ok\"]}");
         String body = new String(conn2.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
@@ -165,12 +137,8 @@ class RegisterSchemasHandlerIT {
     }
 
     /**
-     * Verifies that a backward-incompatible schema change is rejected by the real
-     * Schema Registry with a 409, and that the handler surfaces it as a 409 response.
-     * <p>
-     * Adding a NOT NULL column without a default produces a required (non-nullable)
-     * Avro field. Because the real Schema Registry enforces BACKWARD compatibility
-     * by default, it rejects this change without any mocking.
+     * A NOT NULL column without a default maps to a required Avro field, which is backward-incompatible.
+     * The empty table allows the DDL without a DEFAULT value.
      */
     @Test
     void incompatibleEvolutionReturns409() throws Exception {
@@ -180,27 +148,19 @@ class RegisterSchemasHandlerIT {
                 "  name TEXT NOT NULL" +
                 ")");
 
-        // First registration: v1 succeeds
         HttpURLConnection conn1 = post("{\"tables\":[\"public.evolution_bad\"]}");
         assertThat(conn1.getResponseCode()).isEqualTo(200);
         conn1.getInputStream().readAllBytes(); // drain
 
-        // Evolve the table: NOT NULL column without a default → required Avro field
-        // → backward-incompatible; the empty table allows the DDL without a DEFAULT.
         execute("ALTER TABLE public.evolution_bad ADD COLUMN required_flag TEXT NOT NULL");
 
-        // The real Schema Registry rejects the incompatible schema with 409
         HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_bad\"]}");
-        int responseCode = conn2.getResponseCode(); // triggers the response; populates getErrorStream()
+        int responseCode = conn2.getResponseCode();
         java.io.InputStream errStream = conn2.getErrorStream();
         String errorBody = errStream != null ? new String(errStream.readAllBytes(), StandardCharsets.UTF_8) : "";
         assertThat(responseCode).isEqualTo(409);
         assertThat(errorBody).contains("Schema for table public.evolution_bad is incompatible with an earlier schema for subject");
     }
-
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
 
     private static Configuration buildConfig() {
         Properties props = new Properties();

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.sun.net.httpserver.HttpServer;
+
+import io.debezium.config.Configuration;
+import io.debezium.schematranslator.schema.AvroSchemaConverter;
+import io.debezium.schematranslator.schema.DebeziumSchemaReader;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+
+/**
+ * End-to-end integration test for {@link RegisterSchemasHandler}.
+ * <p>
+ * Exercises the full registration pipeline:
+ * HTTP request → handler → PostgreSQL (Testcontainers) → Avro conversion
+ * → real Confluent Schema Registry (Testcontainers) → HTTP response.
+ * <p>
+ * All three containers share a Docker network so Schema Registry can reach
+ * Kafka's internal broker listener. A fresh component chain is created per
+ * test to prevent Confluent client cache carryover between tests.
+ */
+@Testcontainers
+class RegisterSchemasHandlerIT {
+
+    // -------------------------------------------------------------------------
+    // Shared Docker network and containers (started once for the test class)
+    // -------------------------------------------------------------------------
+
+    private static final Network network = Network.newNetwork();
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17")
+            .withCommand("postgres", "-c", "wal_level=logical",
+                    "-c", "max_replication_slots=4",
+                    "-c", "max_wal_senders=4");
+
+    @Container
+    @SuppressWarnings("deprecation")
+    static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.6.1"))
+            .withNetwork(network)
+            .withNetworkAliases("kafka");
+
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> schemaRegistry = new GenericContainer<>(
+            DockerImageName.parse("confluentinc/cp-schema-registry:7.6.1"))
+            .withNetwork(network)
+            .withExposedPorts(8081)
+            .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
+            .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
+            .dependsOn(kafka)
+            .waitingFor(Wait.forHttp("/subjects")
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(30)));
+
+    // -------------------------------------------------------------------------
+    // Per-test handler server (recreated to avoid Confluent client cache carryover)
+    // -------------------------------------------------------------------------
+
+    private HttpServer handlerServer;
+    private int handlerPort;
+    private DebeziumSchemaReader reader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        reader = new DebeziumSchemaReader(buildConfig());
+        String srUrl = "http://localhost:" + schemaRegistry.getMappedPort(8081);
+        SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(srUrl);
+        RegisterSchemasHandler handler = new RegisterSchemasHandler(reader, new AvroSchemaConverter(), publisher);
+
+        handlerServer = HttpServer.create(new InetSocketAddress(0), 0);
+        handlerServer.createContext("/api/v1/schema-translator/register-schemas", handler);
+        handlerServer.start();
+        handlerPort = handlerServer.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        handlerServer.stop(0);
+        reader.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void registersSchemaEndToEnd() throws Exception {
+        execute("CREATE TABLE IF NOT EXISTS public.products (" +
+                "  id SERIAL PRIMARY KEY," +
+                "  name VARCHAR(100) NOT NULL," +
+                "  price NUMERIC" +
+                ")");
+
+        HttpURLConnection conn = post("{\"tables\":[\"public.products\"]}");
+        String body = new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(conn.getResponseCode()).isEqualTo(200);
+        assertThat(body).contains("\"subject\":\"test.public.products-value\"");
+        assertThat(body).contains("\"subject\":\"test.public.products-key\"");
+        assertThat(body.split("\"table\":\"public.products\"", -1)).hasSize(3); // 2 occurrences → 3 parts
+    }
+
+    /**
+     * Verifies that adding a nullable column to an existing table produces a new
+     * schema version (v2) on re-registration.
+     * <p>
+     * Adding a nullable column is backward-compatible in Avro because Debezium
+     * maps it to an optional field (null union + default), so the real Schema
+     * Registry accepts it as v2.
+     */
+    @Test
+    void evolvedSchemaIsRegisteredAsVersion2() throws Exception {
+        execute("DROP TABLE IF EXISTS public.evolution_ok");
+        execute("CREATE TABLE public.evolution_ok (" +
+                "  id SERIAL PRIMARY KEY," +
+                "  name TEXT NOT NULL" +
+                ")");
+
+        // First registration: value and key schemas at version 1
+        HttpURLConnection conn1 = post("{\"tables\":[\"public.evolution_ok\"]}");
+        assertThat(conn1.getResponseCode()).isEqualTo(200);
+        conn1.getInputStream().readAllBytes(); // drain
+
+        // Evolve the table: nullable column → backward-compatible Avro optional field
+        execute("ALTER TABLE public.evolution_ok ADD COLUMN notes TEXT");
+
+        // Second registration: value schema has a new optional field → version 2
+        HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_ok\"]}");
+        String body = new String(conn2.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(conn2.getResponseCode()).isEqualTo(200);
+        assertThat(body).contains("\"subject\":\"test.public.evolution_ok-value\"");
+        assertThat(body).contains("\"version\":2");
+    }
+
+    /**
+     * Verifies that a backward-incompatible schema change is rejected by the real
+     * Schema Registry with a 409, and that the handler surfaces it as a 409 response.
+     * <p>
+     * Adding a NOT NULL column without a default produces a required (non-nullable)
+     * Avro field. Because the real Schema Registry enforces BACKWARD compatibility
+     * by default, it rejects this change without any mocking.
+     */
+    @Test
+    void incompatibleEvolutionReturns409() throws Exception {
+        execute("DROP TABLE IF EXISTS public.evolution_bad");
+        execute("CREATE TABLE public.evolution_bad (" +
+                "  id SERIAL PRIMARY KEY," +
+                "  name TEXT NOT NULL" +
+                ")");
+
+        // First registration: v1 succeeds
+        HttpURLConnection conn1 = post("{\"tables\":[\"public.evolution_bad\"]}");
+        assertThat(conn1.getResponseCode()).isEqualTo(200);
+        conn1.getInputStream().readAllBytes(); // drain
+
+        // Evolve the table: NOT NULL column without a default → required Avro field
+        // → backward-incompatible; the empty table allows the DDL without a DEFAULT.
+        execute("ALTER TABLE public.evolution_bad ADD COLUMN required_flag TEXT NOT NULL");
+
+        // The real Schema Registry rejects the incompatible schema with 409
+        HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_bad\"]}");
+        int responseCode = conn2.getResponseCode(); // triggers the response; populates getErrorStream()
+        java.io.InputStream errStream = conn2.getErrorStream();
+        String errorBody = errStream != null ? new String(errStream.readAllBytes(), StandardCharsets.UTF_8) : "";
+        assertThat(responseCode).isEqualTo(409);
+        assertThat(errorBody).contains("Schema for table public.evolution_bad is incompatible with an earlier schema for subject");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static Configuration buildConfig() {
+        Properties props = new Properties();
+        props.put("database.hostname", postgres.getHost());
+        props.put("database.port", String.valueOf(postgres.getMappedPort(5432)));
+        props.put("database.dbname", postgres.getDatabaseName());
+        props.put("database.user", postgres.getUsername());
+        props.put("database.password", postgres.getPassword());
+        props.put("database.sslmode", "disable");
+        props.put("topic.prefix", "test");
+        props.put("schema.name.adjustment.mode", "avro");
+        props.put("plugin.name", "pgoutput");
+        props.put("slot.name", "dummy_slot");
+        return Configuration.from(props);
+    }
+
+    private HttpURLConnection post(String jsonBody) throws Exception {
+        URL url = new URL("http://localhost:" + handlerPort
+                + "/api/v1/schema-translator/register-schemas");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        byte[] bytes = jsonBody.getBytes(StandardCharsets.UTF_8);
+        conn.getOutputStream().write(bytes);
+        conn.getOutputStream().flush();
+        return conn;
+    }
+
+    private void execute(String sql) throws Exception {
+        try (Connection conn = DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -155,11 +155,14 @@ class RegisterSchemasHandlerIT {
         execute("ALTER TABLE public.evolution_bad ADD COLUMN required_flag TEXT NOT NULL");
 
         HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_bad\"]}");
-        int responseCode = conn2.getResponseCode();
+        assertThat(conn2.getResponseCode()).isEqualTo(409);
         java.io.InputStream errStream = conn2.getErrorStream();
         String errorBody = errStream != null ? new String(errStream.readAllBytes(), StandardCharsets.UTF_8) : "";
-        assertThat(responseCode).isEqualTo(409);
-        assertThat(errorBody).contains("Schema for table public.evolution_bad is incompatible with an earlier schema for subject");
+        com.fasterxml.jackson.databind.JsonNode errorJson = new com.fasterxml.jackson.databind.ObjectMapper().readTree(errorBody);
+        assertThat(errorJson.get("error").get("message").asText())
+                .isEqualTo("One or more schemas are incompatible with an existing version");
+        assertThat(errorJson.get("error").get("errors").get(0).asText())
+                .contains("Schema for table public.evolution_bad is incompatible with an earlier schema for subject");
     }
 
     private static Configuration buildConfig() {

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+
+import io.debezium.data.Envelope;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+import io.debezium.schematranslator.model.RegisteredSchema;
+import io.debezium.schematranslator.schema.AvroSchemaConverter;
+import io.debezium.schematranslator.schema.DebeziumSchemaReader;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
+import io.debezium.spi.topic.TopicNamingStrategy;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterSchemasHandlerTest {
+
+    @Mock
+    private DebeziumSchemaReader schemaReader;
+    @Mock
+    private AvroSchemaConverter avroConverter;
+    @Mock
+    private SchemaRegistryPublisher publisher;
+
+    private RegisterSchemasHandler handler;
+    private ByteArrayOutputStream responseBody;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        handler = new RegisterSchemasHandler(schemaReader, avroConverter, publisher);
+    }
+
+    @Test
+    void nonPostMethodReturns405() throws Exception {
+        HttpExchange exchange = mockExchange("GET", "");
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(405), anyLong());
+    }
+
+    @Test
+    void invalidJsonBodyReturns400() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "not-json");
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(400), anyLong());
+    }
+
+    @Test
+    void missingTablesFieldReturns400() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{}");
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(400), anyLong());
+        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("tables");
+    }
+
+    @Test
+    void emptyTablesListReturns400() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[]}");
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(400), anyLong());
+    }
+
+    @Test
+    void postgresErrorReturns500() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        when(schemaReader.readSchemas(anyList())).thenThrow(new RuntimeException("Connection refused"));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(500), anyLong());
+        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("Connection refused");
+    }
+
+    @Test
+    void schemaIncompatibilityReturns409() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        setupSchemaReaderAndConverter();
+        doThrow(new SchemaIncompatibilityException("incompatible schema", new Exception()))
+                .when(publisher).register(any(), any(), any());
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(409), anyLong());
+        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("incompatible schema");
+    }
+
+    @Test
+    void schemaRegistryIoErrorReturns500() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        setupSchemaReaderAndConverter();
+        doThrow(new IOException("network error"))
+                .when(publisher).register(any(), any(), any());
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(500), anyLong());
+        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("network error");
+    }
+
+    @Test
+    void successfulRegistrationReturns200WithResults() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        setupSchemaReaderAndConverter();
+        when(publisher.register(any(), any(), any()))
+                .thenReturn(new RegisteredSchema("public.users", "test.public.users-value", 1, 1));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(200), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("registered_schemas")).hasSize(1);
+        JsonNode registered = response.get("registered_schemas").get(0);
+        assertThat(registered.get("table").asText()).isEqualTo("public.users");
+        assertThat(registered.get("subject").asText()).isEqualTo("test.public.users-value");
+        assertThat(registered.get("schema_id").asInt()).isEqualTo(1);
+    }
+
+    // --- helpers ---
+
+    @SuppressWarnings("unchecked")
+    private void setupSchemaReaderAndConverter() throws Exception {
+        TableId tableId = new TableId(null, "public", "users");
+        TableSchema tableSchema = mock(TableSchema.class);
+        Envelope envelope = mock(Envelope.class);
+        when(tableSchema.getEnvelopeSchema()).thenReturn(envelope);
+        when(envelope.schema()).thenReturn(SchemaBuilder.struct().name("Envelope").build());
+
+        Map<TableId, TableSchema> schemas = new LinkedHashMap<>();
+        schemas.put(tableId, tableSchema);
+        when(schemaReader.readSchemas(List.of("public.users"))).thenReturn(schemas);
+
+        TopicNamingStrategy<TableId> strategy = mock(TopicNamingStrategy.class);
+        when(strategy.dataChangeTopic(tableId)).thenReturn("test.public.users");
+        when(schemaReader.getTopicNamingStrategy()).thenReturn(strategy);
+
+        when(avroConverter.toAvro(any()))
+                .thenReturn(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+    }
+
+    private HttpExchange mockExchange(String method, String body) throws IOException {
+        HttpExchange exchange = mock(HttpExchange.class);
+        when(exchange.getRequestMethod()).thenReturn(method);
+        lenient().when(exchange.getRequestBody())
+                .thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        when(exchange.getResponseHeaders()).thenReturn(new Headers());
+        responseBody = new ByteArrayOutputStream();
+        when(exchange.getResponseBody()).thenReturn(responseBody);
+        return exchange;
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -1,41 +1,9 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.api;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
-
 import io.debezium.data.Envelope;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
@@ -45,6 +13,24 @@ import io.debezium.schematranslator.schema.DebeziumSchemaReader;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
 import io.debezium.spi.topic.TopicNamingStrategy;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RegisterSchemasHandlerTest {
@@ -160,8 +146,6 @@ class RegisterSchemasHandlerTest {
         assertThat(key.get("subject").asText()).isEqualTo("test.public.users-key");
         assertThat(key.get("schema_id").asInt()).isEqualTo(2);
     }
-
-    // --- helpers ---
 
     @SuppressWarnings("unchecked")
     private void setupSchemaReaderAndConverter() throws Exception {

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -76,7 +76,8 @@ class RegisterSchemasHandlerTest {
         handler.handle(exchange);
 
         verify(exchange).sendResponseHeaders(eq(400), anyLong());
-        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("tables");
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText()).contains("tables");
     }
 
     @Test
@@ -96,7 +97,8 @@ class RegisterSchemasHandlerTest {
         handler.handle(exchange);
 
         verify(exchange).sendResponseHeaders(eq(500), anyLong());
-        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("Connection refused");
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText()).contains("Connection refused");
     }
 
     @Test
@@ -109,7 +111,30 @@ class RegisterSchemasHandlerTest {
         handler.handle(exchange);
 
         verify(exchange).sendResponseHeaders(eq(409), anyLong());
-        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("incompatible schema");
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText())
+                .isEqualTo("One or more schemas are incompatible with an existing version");
+        assertThat(response.get("error").get("errors")).hasSize(1);
+        assertThat(response.get("error").get("errors").get(0).asText()).contains("incompatible schema");
+    }
+
+    @Test
+    void multipleSchemaIncompatibilitiesReturnsAllErrors() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\",\"public.orders\"]}");
+        setupSchemaReaderAndConverterForTables();
+        doThrow(new SchemaIncompatibilityException("incompatible schema for users", new Exception()))
+                .when(publisher).register(eq("public.users"), any(), any());
+        doThrow(new SchemaIncompatibilityException("incompatible schema for orders", new Exception()))
+                .when(publisher).register(eq("public.orders"), any(), any());
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(409), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        JsonNode errors = response.get("error").get("errors");
+        assertThat(errors).hasSize(2);
+        assertThat(errors.get(0).asText()).contains("incompatible schema for users");
+        assertThat(errors.get(1).asText()).contains("incompatible schema for orders");
     }
 
     @Test
@@ -122,7 +147,8 @@ class RegisterSchemasHandlerTest {
         handler.handle(exchange);
 
         verify(exchange).sendResponseHeaders(eq(500), anyLong());
-        assertThat(responseBody.toString(StandardCharsets.UTF_8)).contains("network error");
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText()).contains("network error");
     }
 
     @Test
@@ -145,6 +171,37 @@ class RegisterSchemasHandlerTest {
         JsonNode key = response.get("registered_schemas").get(1);
         assertThat(key.get("subject").asText()).isEqualTo("test.public.users-key");
         assertThat(key.get("schema_id").asInt()).isEqualTo(2);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupSchemaReaderAndConverterForTables() throws Exception {
+        TableId usersId = new TableId(null, "public", "users");
+        TableId ordersId = new TableId(null, "public", "orders");
+
+        TableSchema usersSchema = mock(TableSchema.class);
+        Envelope usersEnvelope = mock(Envelope.class);
+        when(usersSchema.getEnvelopeSchema()).thenReturn(usersEnvelope);
+        when(usersEnvelope.schema()).thenReturn(SchemaBuilder.struct().name("UsersEnvelope").build());
+        when(usersSchema.keySchema()).thenReturn(null);
+
+        TableSchema ordersSchema = mock(TableSchema.class);
+        Envelope ordersEnvelope = mock(Envelope.class);
+        when(ordersSchema.getEnvelopeSchema()).thenReturn(ordersEnvelope);
+        when(ordersEnvelope.schema()).thenReturn(SchemaBuilder.struct().name("OrdersEnvelope").build());
+        when(ordersSchema.keySchema()).thenReturn(null);
+
+        Map<TableId, TableSchema> schemas = new LinkedHashMap<>();
+        schemas.put(usersId, usersSchema);
+        schemas.put(ordersId, ordersSchema);
+        when(schemaReader.readSchemas(List.of("public.users", "public.orders"))).thenReturn(schemas);
+
+        TopicNamingStrategy<TableId> strategy = mock(TopicNamingStrategy.class);
+        when(strategy.dataChangeTopic(usersId)).thenReturn("test.public.users");
+        when(strategy.dataChangeTopic(ordersId)).thenReturn("test.public.orders");
+        when(schemaReader.getTopicNamingStrategy()).thenReturn(strategy);
+
+        when(avroConverter.toAvro(any()))
+                .thenReturn(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
     }
 
     @SuppressWarnings("unchecked")

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -143,18 +143,22 @@ class RegisterSchemasHandlerTest {
     void successfulRegistrationReturns200WithResults() throws Exception {
         HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
         setupSchemaReaderAndConverter();
-        when(publisher.register(any(), any(), any()))
+        when(publisher.register(eq("public.users"), eq("test.public.users-value"), any()))
                 .thenReturn(new RegisteredSchema("public.users", "test.public.users-value", 1, 1));
+        when(publisher.register(eq("public.users"), eq("test.public.users-key"), any()))
+                .thenReturn(new RegisteredSchema("public.users", "test.public.users-key", 2, 1));
 
         handler.handle(exchange);
 
         verify(exchange).sendResponseHeaders(eq(200), anyLong());
         JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
-        assertThat(response.get("registered_schemas")).hasSize(1);
-        JsonNode registered = response.get("registered_schemas").get(0);
-        assertThat(registered.get("table").asText()).isEqualTo("public.users");
-        assertThat(registered.get("subject").asText()).isEqualTo("test.public.users-value");
-        assertThat(registered.get("schema_id").asInt()).isEqualTo(1);
+        assertThat(response.get("registered_schemas")).hasSize(2);
+        JsonNode value = response.get("registered_schemas").get(0);
+        assertThat(value.get("subject").asText()).isEqualTo("test.public.users-value");
+        assertThat(value.get("schema_id").asInt()).isEqualTo(1);
+        JsonNode key = response.get("registered_schemas").get(1);
+        assertThat(key.get("subject").asText()).isEqualTo("test.public.users-key");
+        assertThat(key.get("schema_id").asInt()).isEqualTo(2);
     }
 
     // --- helpers ---
@@ -166,6 +170,8 @@ class RegisterSchemasHandlerTest {
         Envelope envelope = mock(Envelope.class);
         when(tableSchema.getEnvelopeSchema()).thenReturn(envelope);
         when(envelope.schema()).thenReturn(SchemaBuilder.struct().name("Envelope").build());
+        when(tableSchema.keySchema()).thenReturn(SchemaBuilder.struct().name("Key")
+                .field("id", org.apache.kafka.connect.data.Schema.INT32_SCHEMA).build());
 
         Map<TableId, TableSchema> schemas = new LinkedHashMap<>();
         schemas.put(tableId, tableSchema);

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaConverterTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaConverterTest.java
@@ -1,17 +1,12 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.schema;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.avro.Schema.Type;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AvroSchemaConverterTest {
 

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaConverterTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaConverterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.avro.Schema.Type;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AvroSchemaConverterTest {
+
+    private AvroSchemaConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new AvroSchemaConverter();
+    }
+
+    @Test
+    void convertsStructSchemaToAvroRecord() {
+        Schema connectSchema = SchemaBuilder.struct()
+                .name("test.Value")
+                .field("id", SchemaBuilder.int32().build())
+                .field("name", SchemaBuilder.string().optional().build())
+                .build();
+
+        org.apache.avro.Schema avroSchema = converter.toAvro(connectSchema);
+
+        assertThat(avroSchema.getType()).isEqualTo(Type.RECORD);
+        assertThat(avroSchema.getName()).isEqualTo("Value");
+        assertThat(avroSchema.getNamespace()).isEqualTo("test");
+        assertThat(avroSchema.getFields()).hasSize(2);
+        assertThat(avroSchema.getField("id")).isNotNull();
+        assertThat(avroSchema.getField("name")).isNotNull();
+    }
+
+    @Test
+    void convertsNestedStructToNestedAvroRecord() {
+        Schema inner = SchemaBuilder.struct()
+                .name("test.Inner")
+                .field("value", SchemaBuilder.int64().build())
+                .build();
+        Schema outer = SchemaBuilder.struct()
+                .name("test.Outer")
+                .field("nested", inner)
+                .build();
+
+        org.apache.avro.Schema avroSchema = converter.toAvro(outer);
+
+        assertThat(avroSchema.getType()).isEqualTo(Type.RECORD);
+        org.apache.avro.Schema.Field nestedField = avroSchema.getField("nested");
+        assertThat(nestedField).isNotNull();
+        assertThat(nestedField.schema().getType()).isEqualTo(Type.RECORD);
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+
+@Testcontainers
+class DebeziumSchemaReaderIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17")
+            .withCommand("postgres", "-c", "wal_level=logical",
+                    "-c", "max_replication_slots=4",
+                    "-c", "max_wal_senders=4");
+
+    private DebeziumSchemaReader reader;
+
+    @BeforeEach
+    void setUp() {
+        reader = new DebeziumSchemaReader(buildConfig());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        reader.close();
+    }
+
+    @Test
+    void readsSchemasForTableWithCorrectFields() throws Exception {
+        execute("CREATE TABLE IF NOT EXISTS public.users (" +
+                "  id SERIAL PRIMARY KEY," +
+                "  name VARCHAR(100) NOT NULL," +
+                "  email VARCHAR(255)" +
+                ")");
+
+        Map<TableId, TableSchema> schemas = reader.readSchemas(java.util.List.of("public.users"));
+
+        assertThat(schemas).hasSize(1);
+        TableSchema tableSchema = schemas.values().iterator().next();
+        assertThat(tableSchema.valueSchema().fields())
+                .extracting(org.apache.kafka.connect.data.Field::name)
+                .containsExactlyInAnyOrder("id", "name", "email");
+    }
+
+    @Test
+    void throwsForUnknownTable() {
+        assertThatThrownBy(() -> reader.readSchemas(java.util.List.of("public.nonexistent")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Table not found: public.nonexistent");
+    }
+
+    @Test
+    void unqualifiedTableNameDefaultsToPublicSchema() throws Exception {
+        execute("CREATE TABLE IF NOT EXISTS public.orders (" +
+                "  id SERIAL PRIMARY KEY," +
+                "  amount NUMERIC NOT NULL" +
+                ")");
+
+        Map<TableId, TableSchema> schemas = reader.readSchemas(java.util.List.of("orders"));
+
+        assertThat(schemas).hasSize(1);
+        TableId tableId = schemas.keySet().iterator().next();
+        assertThat(tableId.schema()).isEqualTo("public");
+        assertThat(tableId.table()).isEqualTo("orders");
+    }
+
+    private Configuration buildConfig() {
+        Properties props = new Properties();
+        props.put("database.hostname", postgres.getHost());
+        props.put("database.port", String.valueOf(postgres.getMappedPort(5432)));
+        props.put("database.dbname", postgres.getDatabaseName());
+        props.put("database.user", postgres.getUsername());
+        props.put("database.password", postgres.getPassword());
+        props.put("database.sslmode", "disable");
+        props.put("topic.prefix", "test");
+        props.put("schema.name.adjustment.mode", "avro");
+        props.put("plugin.name", "pgoutput");
+        props.put("slot.name", "dummy_slot");
+        return Configuration.from(props);
+    }
+
+    private void execute(String sql) throws Exception {
+        try (Connection conn = DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderIT.java
@@ -1,19 +1,8 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.schema;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
-import java.util.Map;
-import java.util.Properties;
-
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,9 +10,14 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import io.debezium.config.Configuration;
-import io.debezium.relational.TableId;
-import io.debezium.relational.TableSchema;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
 class DebeziumSchemaReaderIT {

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
@@ -1,21 +1,4 @@
-/*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.debezium.schematranslator.schema;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-
-import org.apache.avro.Schema;
-import org.junit.jupiter.api.Test;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
@@ -23,6 +6,17 @@ import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.debezium.schematranslator.model.RegisteredSchema;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 
 class SchemaRegistryPublisherTest {
 

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.schematranslator.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.debezium.schematranslator.model.RegisteredSchema;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
+
+class SchemaRegistryPublisherTest {
+
+    private static final Schema AVRO_SCHEMA = Schema.create(Schema.Type.STRING);
+
+    @Test
+    void registerReturnsSchemaIdAndVersion() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.register(eq("test.public.users-value"), any(ParsedSchema.class))).thenReturn(42);
+            when(client.getLatestSchemaMetadata("test.public.users-value"))
+                    .thenReturn(new SchemaMetadata(42, 3, "{}"));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            RegisteredSchema result = publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA);
+
+            assertThat(result.getTable()).isEqualTo("public.users");
+            assertThat(result.getSubject()).isEqualTo("test.public.users-value");
+            assertThat(result.getSchemaId()).isEqualTo(42);
+            assertThat(result.getVersion()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void register409ThrowsSchemaIncompatibilityException() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.register(any(), any(ParsedSchema.class)))
+                    .thenThrow(new RestClientException("Schema being registered is incompatible", 409, 409));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            assertThatThrownBy(() -> publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA))
+                    .isInstanceOf(SchemaIncompatibilityException.class)
+                    .hasMessageContaining("public.users")
+                    .hasMessageContaining("test.public.users-value");
+        }
+    }
+
+    @Test
+    void registerNon409RestClientExceptionThrowsIOException() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.register(any(), any(ParsedSchema.class)))
+                    .thenThrow(new RestClientException("Internal Server Error", 500, 50001));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            assertThatThrownBy(() -> publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("HTTP 500");
+        }
+    }
+}

--- a/debezium-schema-translator/src/test/resources/docker.properties
+++ b/debezium-schema-translator/src/test/resources/docker.properties
@@ -1,0 +1,3 @@
+# docker-java loads this file from the classpath to configure the Docker client.
+# Docker Engine 27+ dropped support for API versions below 1.44.
+api.version=1.44

--- a/debezium-schema-translator/src/test/resources/testcontainers.properties
+++ b/debezium-schema-translator/src/test/resources/testcontainers.properties
@@ -1,0 +1,3 @@
+# testcontainers reads this file from the classpath.
+# Disable Ryuk resource reaper to avoid pulling its image on every run.
+ryuk.disabled=true

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
         <module>quarkus-debezium-parent</module>
         <module>debezium-openlineage</module>
         <module>debezium-common</module>
+        <module>debezium-schema-translator</module>
     </modules>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary

This PR introduces the `debezium-schema-translator` module ([ADR](https://docs.google.com/document/d/12jFNBuNmhXG2sPwgH7Hp9410fvSrbp4UudctiEhPLS8/edit?tab=t.0#heading=h.4ocygg1bsnsl)), a standalone HTTP service that reads Postgres table schemas and registers them as Avro schemas in the Confluent Schema Registry.

This service is a building block for a CI-based enforcement mechanism. Instead of parsing SQL or maintaining a list of breaking DDL patterns, the CI check will:

1. Use this service to translate the current Postgres schema into its Debezium/Avro representation (the same translation Debezium performs at runtime)
2. Submit the resulting schema to the Schema Registry compatibility API to determine whether the migration would break CDC

This ensures the validation is always aligned with production Debezium behavior and removes the need to maintain fragile DDL heuristics.

The service exposes two endpoints:

- `GET /api/v1/schema-translator/health` — liveness check
- `POST /api/v1/schema-translator/register-schemas` — takes a list of table names and registers both the value (envelope) and key Avro schemas under the standard Debezium subject names (`{topic_prefix}.{schema}.{table}-value` / `-key`)

It reuses the exact same Debezium Postgres connector internals (`PostgresConnection`, `PostgresValueConverter`, `TableSchemaBuilder`) to guarantee the produced schemas are identical to what the connector would register during normal CDC operation. The Postgres connection is initialized lazily on the first request. A `docker-compose.yml` is included for local development.

## Testing

- Unit tests covering schema registration logic, request parsing, and error handling (`RegisterSchemasHandlerTest`, `AvroSchemaConverterTest`, `SchemaRegistryPublisherTest`)
- Integration tests using Testcontainers (real Postgres + real Confluent Schema Registry) validating the full registration pipeline end-to-end (`RegisterSchemasHandlerIT`, `DebeziumSchemaReaderIT`)

Tests pass locally when running `mvn verify -pl debezium-schema-translator`