### PR TITLE
[MARS-5790] Add TotalRowsToScan JMX metric for incremental snapshot progress

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresIncrementalSnapshotHelper.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresIncrementalSnapshotHelper.java
@@ -11,6 +11,7 @@ import java.util.OptionalLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.relational.TableId;
 
 /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresIncrementalSnapshotHelper.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresIncrementalSnapshotHelper.java
@@ -25,10 +25,13 @@ final class PostgresIncrementalSnapshotHelper {
     }
 
     /**
-     * Returns an estimated row count for the given table by querying {@code pg_stat_user_tables.n_live_tup}.
-     * This is a catalog-level estimate maintained by autovacuum and does not require a full table scan or lock.
-     * Returns an empty optional when the estimate is unavailable or zero (e.g. the table has not yet been
-     * analyzed by autovacuum, making a zero value unreliable as a progress estimate).
+     * Returns an estimated row count for the given table.
+     * <p>
+     * First tries {@code pg_stat_user_tables.n_live_tup}, a live-tuple estimate maintained by autovacuum.
+     * If that value is zero (e.g. autovacuum has not yet run on the table), falls back to
+     * {@code pg_class.reltuples}, the planner's row-count estimate which is populated after the first
+     * {@code ANALYZE} or table creation. Returns an empty optional only when both sources are unavailable
+     * or non-positive.
      *
      * @param connection the PostgreSQL JDBC connection
      * @param tableId    the table to estimate
@@ -37,14 +40,18 @@ final class PostgresIncrementalSnapshotHelper {
     static OptionalLong estimateRowCount(PostgresConnection connection, TableId tableId) {
         try {
             Long estimate = connection.prepareQueryAndMap(
-                    "SELECT n_live_tup FROM pg_stat_user_tables WHERE schemaname = ? AND relname = ?",
+                    "SELECT CASE WHEN s.n_live_tup > 0 THEN s.n_live_tup" +
+                            "          WHEN c.reltuples > 0 THEN c.reltuples::bigint" +
+                            "          ELSE 0 END" +
+                            " FROM pg_stat_user_tables s" +
+                            " JOIN pg_class c ON c.relname = s.relname" +
+                            "  AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = s.schemaname)" +
+                            " WHERE s.schemaname = ? AND s.relname = ?",
                     statement -> {
                         statement.setString(1, tableId.schema());
                         statement.setString(2, tableId.table());
                     },
                     rs -> rs.next() ? rs.getLong(1) : null);
-            // n_live_tup is 0 for tables that have never been analyzed; treat as unknown rather
-            // than reporting a misleading zero total.
             if (estimate == null || estimate == 0L) {
                 return OptionalLong.empty();
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresIncrementalSnapshotHelper.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresIncrementalSnapshotHelper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.sql.SQLException;
+import java.util.OptionalLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.relational.TableId;
+
+/**
+ * Shared utilities for PostgreSQL incremental snapshot implementations.
+ */
+final class PostgresIncrementalSnapshotHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresIncrementalSnapshotHelper.class);
+
+    private PostgresIncrementalSnapshotHelper() {
+    }
+
+    /**
+     * Returns an estimated row count for the given table by querying {@code pg_stat_user_tables.n_live_tup}.
+     * This is a catalog-level estimate maintained by autovacuum and does not require a full table scan or lock.
+     * Returns an empty optional when the estimate is unavailable or zero (e.g. the table has not yet been
+     * analyzed by autovacuum, making a zero value unreliable as a progress estimate).
+     *
+     * @param connection the PostgreSQL JDBC connection
+     * @param tableId    the table to estimate
+     * @return an {@link OptionalLong} containing the estimate, or empty if not available
+     */
+    static OptionalLong estimateRowCount(PostgresConnection connection, TableId tableId) {
+        try {
+            Long estimate = connection.prepareQueryAndMap(
+                    "SELECT n_live_tup FROM pg_stat_user_tables WHERE schemaname = ? AND relname = ?",
+                    statement -> {
+                        statement.setString(1, tableId.schema());
+                        statement.setString(2, tableId.table());
+                    },
+                    rs -> rs.next() ? rs.getLong(1) : null);
+            // n_live_tup is 0 for tables that have never been analyzed; treat as unknown rather
+            // than reporting a misleading zero total.
+            if (estimate == null || estimate == 0L) {
+                return OptionalLong.empty();
+            }
+            return OptionalLong.of(estimate);
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Failed to estimate row count for table '{}': {}", tableId, e.getMessage());
+            return OptionalLong.empty();
+        }
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -171,20 +171,7 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
 
     @Override
     protected OptionalLong estimateRowCount(TableId tableId) {
-        try {
-            Long estimate = jdbcConnection.prepareQueryAndMap(
-                    "SELECT n_live_tup FROM pg_stat_user_tables WHERE schemaname = ? AND relname = ?",
-                    statement -> {
-                        statement.setString(1, tableId.schema());
-                        statement.setString(2, tableId.table());
-                    },
-                    rs -> rs.next() ? rs.getLong(1) : null);
-            return estimate != null ? OptionalLong.of(estimate) : OptionalLong.empty();
-        }
-        catch (SQLException e) {
-            LOGGER.warn("Failed to estimate row count for table '{}': {}", tableId, e.getMessage());
-            return OptionalLong.empty();
-        }
+        return PostgresIncrementalSnapshotHelper.estimateRowCount(jdbcConnection, tableId);
     }
 
     private void readUntilNewTransactionChange(P partition, OffsetContext offsetContext) throws InterruptedException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.postgresql;
 
 import java.sql.SQLException;
+import java.util.OptionalLong;
 import java.util.function.Consumer;
 
 import org.slf4j.Logger;
@@ -166,6 +167,24 @@ public class PostgresReadOnlyIncrementalSnapshotChangeEventSource<P extends Post
         LOGGER.debug("Refreshing table '{}' schema for incremental snapshot.", table.id());
         schema.refreshFromIncrementalSnapshot(jdbcConnection, table.id());
         return schema.tableFor(table.id());
+    }
+
+    @Override
+    protected OptionalLong estimateRowCount(TableId tableId) {
+        try {
+            Long estimate = jdbcConnection.prepareQueryAndMap(
+                    "SELECT n_live_tup FROM pg_stat_user_tables WHERE schemaname = ? AND relname = ?",
+                    statement -> {
+                        statement.setString(1, tableId.schema());
+                        statement.setString(2, tableId.table());
+                    },
+                    rs -> rs.next() ? rs.getLong(1) : null);
+            return estimate != null ? OptionalLong.of(estimate) : OptionalLong.empty();
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Failed to estimate row count for table '{}': {}", tableId, e.getMessage());
+            return OptionalLong.empty();
+        }
     }
 
     private void readUntilNewTransactionChange(P partition, OffsetContext offsetContext) throws InterruptedException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.postgresql;
 
 import java.sql.SQLException;
+import java.util.OptionalLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,5 +57,23 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
         LOGGER.debug("Refreshing table '{}' schema for incremental snapshot.", table.id());
         schema.refreshFromIncrementalSnapshot(jdbcConnection, table.id());
         return schema.tableFor(table.id());
+    }
+
+    @Override
+    protected OptionalLong estimateRowCount(TableId tableId) {
+        try {
+            Long estimate = jdbcConnection.prepareQueryAndMap(
+                    "SELECT n_live_tup FROM pg_stat_user_tables WHERE schemaname = ? AND relname = ?",
+                    statement -> {
+                        statement.setString(1, tableId.schema());
+                        statement.setString(2, tableId.table());
+                    },
+                    rs -> rs.next() ? rs.getLong(1) : null);
+            return estimate != null ? OptionalLong.of(estimate) : OptionalLong.empty();
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Failed to estimate row count for table '{}': {}", tableId, e.getMessage());
+            return OptionalLong.empty();
+        }
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -61,19 +61,6 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
 
     @Override
     protected OptionalLong estimateRowCount(TableId tableId) {
-        try {
-            Long estimate = jdbcConnection.prepareQueryAndMap(
-                    "SELECT n_live_tup FROM pg_stat_user_tables WHERE schemaname = ? AND relname = ?",
-                    statement -> {
-                        statement.setString(1, tableId.schema());
-                        statement.setString(2, tableId.table());
-                    },
-                    rs -> rs.next() ? rs.getLong(1) : null);
-            return estimate != null ? OptionalLong.of(estimate) : OptionalLong.empty();
-        }
-        catch (SQLException e) {
-            LOGGER.warn("Failed to estimate row count for table '{}': {}", tableId, e.getMessage());
-            return OptionalLong.empty();
-        }
+        return PostgresIncrementalSnapshotHelper.estimateRowCount(jdbcConnection, tableId);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -257,6 +258,11 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
      * @param tableId the table to generate a query for
      * @return a valid query string
      */
+    @Override
+    protected OptionalLong rowCountForTable(TableId tableId) {
+        return PostgresIncrementalSnapshotHelper.estimateRowCount(jdbcConnection, tableId);
+    }
+
     @Override
     protected Optional<String> getSnapshotSelect(RelationalSnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext,
                                                  TableId tableId, List<String> columns) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -116,6 +116,15 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
         return snapshotMeter.getRowsScanned();
     }
 
+    void totalRowsToScan(TableId tableId, long estimatedRows) {
+        snapshotMeter.totalRowsToScan(tableId, estimatedRows);
+    }
+
+    @Override
+    public ConcurrentMap<String, Long> getTotalRowsToScan() {
+        return snapshotMeter.getTotalRowsToScan();
+    }
+
     void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo) {
         snapshotMeter.currentChunk(chunkId, chunkFrom, chunkTo);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
@@ -79,6 +79,11 @@ class SqlServerSnapshotTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServe
     }
 
     @Override
+    public void totalRowsToScan(SqlServerPartition partition, TableId tableId, long totalRows) {
+        onPartitionEvent(partition, bean -> bean.totalRowsToScan(tableId, totalRows));
+    }
+
+    @Override
     public void currentChunk(SqlServerPartition partition, String chunkId, Object[] chunkFrom, Object[] chunkTo) {
         onPartitionEvent(partition, bean -> bean.currentChunk(chunkId, chunkFrom, chunkTo));
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -42,6 +42,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     private final AtomicLong stopPauseTime = new AtomicLong();
     private final AtomicLong pauseDuration = new AtomicLong();
     private final ConcurrentMap<String, Long> rowsScanned = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> totalRowsToScan = new ConcurrentHashMap<>();
 
     private final ConcurrentMap<String, String> remainingTables = new ConcurrentHashMap<>();
 
@@ -208,6 +209,15 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         return rowsScanned;
     }
 
+    public void totalRowsToScan(TableId tableId, long estimatedRows) {
+        totalRowsToScan.put(tableId.toString(), estimatedRows);
+    }
+
+    @Override
+    public ConcurrentMap<String, Long> getTotalRowsToScan() {
+        return totalRowsToScan;
+    }
+
     public void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo) {
         this.chunkId.set(chunkId);
         this.chunkFrom.set(chunkFrom);
@@ -261,6 +271,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         stopPauseTime.set(0);
         pauseDuration.set(0);
         rowsScanned.clear();
+        totalRowsToScan.clear();
         remainingTables.clear();
         capturedTables.clear();
         chunkId.set(null);

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
@@ -141,6 +141,16 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     }
 
     @Override
+    public void totalRowsToScan(P partition, TableId tableId, long totalRows) {
+        snapshotMeter.totalRowsToScan(tableId, totalRows);
+    }
+
+    @Override
+    public ConcurrentMap<String, Long> getTotalRowsToScan() {
+        return snapshotMeter.getTotalRowsToScan();
+    }
+
+    @Override
     public void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo) {
         snapshotMeter.currentChunk(chunkId, chunkFrom, chunkTo);
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -32,6 +32,8 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
 
     Map<String, Long> getRowsScanned();
 
+    Map<String, Long> getTotalRowsToScan();
+
     String getChunkId();
 
     String getChunkFrom();

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -286,6 +287,10 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                                             ColumnUtils.toArray(rs, currentTable)));
                                 });
                         context.maximumKey(maximumKey);
+                        OptionalLong estimated = estimateRowCount(currentTableId);
+                        if (estimated.isPresent()) {
+                            progressListener.totalRowsToScan(partition, currentTableId, estimated.getAsLong());
+                        }
                     }
                     catch (SQLException e) {
                         LOGGER.error("Failed to read maximum key for table {}", currentTableId, e);
@@ -740,6 +745,18 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         // since schema changes are not emitted as change events in the same way that they are for
         // connectors like MySQL or Oracle
         return table;
+    }
+
+    /**
+     * Returns an estimated row count for the given table, used to populate the {@code TotalRowsToScan} JMX metric.
+     * The default implementation returns an empty optional (no estimate). Connectors may override this method to
+     * provide a fast catalog-based estimate without performing a full table scan.
+     *
+     * @param tableId the table for which to estimate the row count
+     * @return an {@link OptionalLong} containing the estimate, or empty if not available
+     */
+    protected OptionalLong estimateRowCount(TableId tableId) {
+        return OptionalLong.empty();
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -78,6 +78,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
     private final SnapshotProgressListener<P> progressListener;
     private final DataChangeEventListener<P> dataListener;
     private long totalRowsScanned = 0;
+    private boolean rowCountEstimated = false;
 
     private Table currentTable;
 
@@ -290,6 +291,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                         OptionalLong estimated = estimateRowCount(currentTableId);
                         if (estimated.isPresent()) {
                             progressListener.totalRowsToScan(partition, currentTableId, estimated.getAsLong());
+                            rowCountEstimated = true;
                         }
                     }
                     catch (SQLException e) {
@@ -686,6 +688,11 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     private void tableScanCompleted(P partition) {
         progressListener.dataCollectionSnapshotCompleted(partition, currentTable.id(), totalRowsScanned);
+        if (rowCountEstimated) {
+            // Reconcile the estimate with the actual scanned count so the metric reaches exactly 100%.
+            progressListener.totalRowsToScan(partition, currentTable.id(), totalRowsScanned);
+            rowCountEstimated = false;
+        }
         totalRowsScanned = 0;
         // Reset chunk/table information in metrics
         progressListener.currentChunk(partition, null, null, null, null);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -78,7 +78,6 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
     private final SnapshotProgressListener<P> progressListener;
     private final DataChangeEventListener<P> dataListener;
     private long totalRowsScanned = 0;
-    private boolean rowCountEstimated = false;
 
     private Table currentTable;
 
@@ -291,7 +290,6 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                         OptionalLong estimated = estimateRowCount(currentTableId);
                         if (estimated.isPresent()) {
                             progressListener.totalRowsToScan(partition, currentTableId, estimated.getAsLong());
-                            rowCountEstimated = true;
                         }
                     }
                     catch (SQLException e) {
@@ -688,11 +686,10 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     private void tableScanCompleted(P partition) {
         progressListener.dataCollectionSnapshotCompleted(partition, currentTable.id(), totalRowsScanned);
-        if (rowCountEstimated) {
-            // Reconcile the estimate with the actual scanned count so the metric reaches exactly 100%.
-            progressListener.totalRowsToScan(partition, currentTable.id(), totalRowsScanned);
-            rowCountEstimated = false;
-        }
+        // Always set totalRowsToScan to the actual scanned count on completion.
+        // If an estimate was previously set, this reconciles it to exactly 100%.
+        // If no estimate was available (e.g. statistics not yet populated), this ensures the metric is populated.
+        progressListener.totalRowsToScan(partition, currentTable.id(), totalRowsScanned);
         totalRowsScanned = 0;
         // Reset chunk/table information in metrics
         progressListener.currentChunk(partition, null, null, null, null);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListener.java
@@ -34,6 +34,8 @@ public interface SnapshotProgressListener<P extends Partition> {
 
     void rowsScanned(P partition, TableId tableId, long numRows);
 
+    void totalRowsToScan(P partition, TableId tableId, long totalRows);
+
     void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo);
 
     void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo);
@@ -55,6 +57,10 @@ public interface SnapshotProgressListener<P extends Partition> {
 
             @Override
             public void rowsScanned(P partition, TableId tableId, long numRows) {
+            }
+
+            @Override
+            public void totalRowsToScan(P partition, TableId tableId, long totalRows) {
             }
 
             @Override

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -496,6 +496,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
                 final OptionalLong rowCount = rowCountForTable(tableId);
                 rowCountTables.put(tableId, rowCount);
+                rowCount.ifPresent(count -> snapshotProgressListener.totalRowsToScan(snapshotContext.partition, tableId, count));
             }
             else {
                 LOGGER.warn("For table '{}' the select statement was not provided, skipping table", tableId);
@@ -668,6 +669,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             LOGGER.info("\t Finished exporting {} records for table '{}' ({} of {} tables); total duration '{}'",
                     rows, table.id(), tableOrder, tableCount, Strings.duration(clock.currentTimeInMillis() - exportStart));
             snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), rows);
+            snapshotProgressListener.totalRowsToScan(snapshotContext.partition, table.id(), rows);
             notificationService.initialSnapshotNotificationService().notifyCompletedTableSuccessfully(snapshotContext.partition,
                     snapshotContext.offset, table.id().identifier(), rows, snapshotContext.capturedTables);
         }

--- a/debezium-core/src/test/java/io/debezium/pipeline/meters/SnapshotMeterTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/meters/SnapshotMeterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.relational.TableId;
+import io.debezium.util.MockClock;
+
+public class SnapshotMeterTest {
+
+    private SnapshotMeter meter;
+
+    @Before
+    public void setUp() {
+        meter = new SnapshotMeter(new MockClock());
+    }
+
+    @Test
+    public void totalRowsToScanIsEmptyOnNewMeter() {
+        assertThat(meter.getTotalRowsToScan()).isEmpty();
+    }
+
+    @Test
+    public void totalRowsToScanTracksEstimatePerTable() {
+        TableId table1 = TableId.parse("db.public.orders");
+        TableId table2 = TableId.parse("db.public.customers");
+
+        meter.totalRowsToScan(table1, 1000L);
+        meter.totalRowsToScan(table2, 500L);
+
+        assertThat(meter.getTotalRowsToScan())
+                .containsEntry(table1.toString(), 1000L)
+                .containsEntry(table2.toString(), 500L);
+    }
+
+    @Test
+    public void totalRowsToScanOverwritesExistingEstimateForSameTable() {
+        TableId table = TableId.parse("db.public.orders");
+
+        meter.totalRowsToScan(table, 1000L);
+        meter.totalRowsToScan(table, 2000L);
+
+        assertThat(meter.getTotalRowsToScan())
+                .hasSize(1)
+                .containsEntry(table.toString(), 2000L);
+    }
+
+    @Test
+    public void resetClearsTotalRowsToScan() {
+        TableId table = TableId.parse("db.public.orders");
+        meter.totalRowsToScan(table, 1000L);
+
+        meter.reset();
+
+        assertThat(meter.getTotalRowsToScan()).isEmpty();
+    }
+
+    @Test
+    public void resetClearsTotalRowsToScanAlongsideRowsScanned() {
+        TableId table = TableId.parse("db.public.orders");
+        meter.rowsScanned(table, 500L);
+        meter.totalRowsToScan(table, 1000L);
+
+        meter.reset();
+
+        assertThat(meter.getRowsScanned()).isEmpty();
+        assertThat(meter.getTotalRowsToScan()).isEmpty();
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/pipeline/meters/SnapshotMeterTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/meters/SnapshotMeterTest.java
@@ -63,6 +63,18 @@ public class SnapshotMeterTest {
     }
 
     @Test
+    public void totalRowsToScanCanBeReconciledToActualCount() {
+        TableId table = TableId.parse("db.public.orders");
+
+        meter.totalRowsToScan(table, 1000L);
+        // Snapshot finishes with 950 actual rows; reconcile so metric reaches 100%.
+        meter.totalRowsToScan(table, 950L);
+
+        assertThat(meter.getTotalRowsToScan())
+                .containsEntry(table.toString(), 950L);
+    }
+
+    @Test
     public void resetClearsTotalRowsToScanAlongsideRowsScanned() {
         TableId table = TableId.parse("db.public.orders");
         meter.rowsScanned(table, 500L);


### PR DESCRIPTION
## Summary
This PR adds a new `TotalRowsToScan` JMX metric (`Map<String, Long>`) to the incremental snapshot metrics. The existing `RowsScanned` metric tells you how many rows have been processed per table, but there's no way to know how many rows there are in total, making progress estimation impossible.

Once an incremental snapshot or an initial snapshot is triggered, the `TotalRowsToScan` will be populated for that table with a `pg_stat_user_tables` row count, to prevent running expensive `SELECT COUNT(*)` queries. Since `pg_stat_user_tables.n_live_tup` is an estimate updated during vacuum/analyze cycles operation, it may slightly out of date but should be a decent enough trade off.

Due to that, since `RowsScanned` may never reach `TotalRowsToScan`. To guarantee the metric settles at exactly 100% when a table finishes, `TotalRowsToScan` is reconciled with the actual `RowsScanned` value in `tableScanCompleted`.

Similar to the `TotalRowsToScan`, the key in the Map is the table name, so we can even track the progress per table (see Testing).

## Testing
Existing unit and integration tests pass. Added some unit tests.
Tested in my dev env Debezium and verified the metric exists: https://ddstaging.datadoghq.com/metric/summary?filter=jmx.debezium.postgres.&metric=jmx.debezium.postgres.total_rows_to_scan
and that it has the correct value when doing a snapshot:
<img width="1252" height="551" alt="image" src="https://github.com/user-attachments/assets/9cf22d38-e8ab-4b67-9878-edead911ed18" />
