### PR TITLE
[MARS-5733] Return old and new schemas on incompatible schema errors

### DIFF
--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -84,7 +84,7 @@ public class RegisterSchemasHandler implements HttpHandler {
 
         // Register each schema with Schema Registry
         List<RegisteredSchema> results = new ArrayList<>();
-        List<String> incompatibilityErrors = new ArrayList<>();
+        List<ErrorResponse.SchemaError> incompatibilityErrors = new ArrayList<>();
         int tableIndex = 0;
         for (Map.Entry<TableId, TableSchema> entry : tableSchemas.entrySet()) {
             TableId tableId = entry.getKey();
@@ -112,7 +112,7 @@ public class RegisterSchemasHandler implements HttpHandler {
             }
             catch (SchemaIncompatibilityException e) {
                 LOGGER.warn("Schema incompatibility for table '{}': {}", originalTableName, e.getMessage());
-                incompatibilityErrors.add(e.getMessage());
+                incompatibilityErrors.add(new ErrorResponse.SchemaError(e.getMessage(), e.getOldSchema(), e.getNewSchema()));
             }
             catch (IOException e) {
                 LOGGER.error("Failed to register schema for table '{}'", originalTableName, e);

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
@@ -22,12 +22,42 @@ public class ErrorResponse {
         this.error = new ErrorDetail(message, null);
     }
 
-    public ErrorResponse(String message, List<String> errors) {
+    public ErrorResponse(String message, List<SchemaError> errors) {
         this.error = new ErrorDetail(message, errors);
     }
 
     public ErrorDetail getError() {
         return error;
+    }
+
+    public static class SchemaError {
+
+        @JsonProperty("message")
+        private final String message;
+
+        @JsonProperty("old_schema")
+        private final String oldSchema;
+
+        @JsonProperty("new_schema")
+        private final String newSchema;
+
+        public SchemaError(String message, String oldSchema, String newSchema) {
+            this.message = message;
+            this.oldSchema = oldSchema;
+            this.newSchema = newSchema;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getOldSchema() {
+            return oldSchema;
+        }
+
+        public String getNewSchema() {
+            return newSchema;
+        }
     }
 
     public static class ErrorDetail {
@@ -37,9 +67,9 @@ public class ErrorResponse {
 
         @JsonProperty("errors")
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        private final List<String> errors;
+        private final List<SchemaError> errors;
 
-        public ErrorDetail(String message, List<String> errors) {
+        public ErrorDetail(String message, List<SchemaError> errors) {
             this.message = message;
             this.errors = errors;
         }
@@ -48,7 +78,7 @@ public class ErrorResponse {
             return message;
         }
 
-        public List<String> getErrors() {
+        public List<SchemaError> getErrors() {
             return errors;
         }
     }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -49,10 +49,18 @@ public class SchemaRegistryPublisher {
         }
         catch (RestClientException e) {
             if (e.getStatus() == 409) {
+                String oldSchema = null;
+                try {
+                    oldSchema = client.getLatestSchemaMetadata(subject).getSchema();
+                } catch (Exception fetchEx) {
+                    LOGGER.warn("Could not fetch existing schema for subject '{}'", subject, fetchEx);
+                }
                 throw new SchemaIncompatibilityException(
                         "Schema for table " + tableName + " is incompatible with an earlier schema for subject \""
                                 + subject + "\": " + e.getMessage(),
-                        e);
+                        e,
+                        oldSchema,
+                        avroSchema.toString());
             }
             throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
         }
@@ -62,8 +70,21 @@ public class SchemaRegistryPublisher {
      * Thrown when a 409 Conflict is returned by the Schema Registry.
      */
     public static class SchemaIncompatibilityException extends Exception {
-        public SchemaIncompatibilityException(String message, Throwable cause) {
+        private final String oldSchema;
+        private final String newSchema;
+
+        public SchemaIncompatibilityException(String message, Throwable cause, String oldSchema, String newSchema) {
             super(message, cause);
+            this.oldSchema = oldSchema;
+            this.newSchema = newSchema;
+        }
+
+        public String getOldSchema() {
+            return oldSchema;
+        }
+
+        public String getNewSchema() {
+            return newSchema;
         }
     }
 }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -49,17 +49,19 @@ public class SchemaRegistryPublisher {
         }
         catch (RestClientException e) {
             if (e.getStatus() == 409) {
-                String oldSchema = null;
-                String incompatibilityMessage = "Schema for table " + tableName
-                        + " is incompatible with an earlier schema for subject \""
-                        + subject + "\": " + e.getMessage();
+                String oldSchema;
                 try {
                     oldSchema = client.getLatestSchemaMetadata(subject).getSchema();
                 } catch (Exception fetchEx) {
                     LOGGER.warn("Could not fetch existing schema for subject '{}'", subject, fetchEx);
-                    incompatibilityMessage += " (could not retrieve existing schema: " + fetchEx.getMessage() + ")";
+                    oldSchema = "could not retrieve existing schema: " + fetchEx.getMessage();
                 }
-                throw new SchemaIncompatibilityException(incompatibilityMessage, e, oldSchema, avroSchema.toString());
+                throw new SchemaIncompatibilityException(
+                        "Schema for table " + tableName + " is incompatible with an earlier schema for subject \""
+                                + subject + "\": " + e.getMessage(),
+                        e,
+                        oldSchema,
+                        avroSchema.toString());
             }
             throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
         }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -50,17 +50,16 @@ public class SchemaRegistryPublisher {
         catch (RestClientException e) {
             if (e.getStatus() == 409) {
                 String oldSchema = null;
+                String incompatibilityMessage = "Schema for table " + tableName
+                        + " is incompatible with an earlier schema for subject \""
+                        + subject + "\": " + e.getMessage();
                 try {
                     oldSchema = client.getLatestSchemaMetadata(subject).getSchema();
                 } catch (Exception fetchEx) {
                     LOGGER.warn("Could not fetch existing schema for subject '{}'", subject, fetchEx);
+                    incompatibilityMessage += " (could not retrieve existing schema: " + fetchEx.getMessage() + ")";
                 }
-                throw new SchemaIncompatibilityException(
-                        "Schema for table " + tableName + " is incompatible with an earlier schema for subject \""
-                                + subject + "\": " + e.getMessage(),
-                        e,
-                        oldSchema,
-                        avroSchema.toString());
+                throw new SchemaIncompatibilityException(incompatibilityMessage, e, oldSchema, avroSchema.toString());
             }
             throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
         }

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -161,8 +161,13 @@ class RegisterSchemasHandlerIT {
         com.fasterxml.jackson.databind.JsonNode errorJson = new com.fasterxml.jackson.databind.ObjectMapper().readTree(errorBody);
         assertThat(errorJson.get("error").get("message").asText())
                 .isEqualTo("One or more schemas are incompatible with an existing version");
-        assertThat(errorJson.get("error").get("errors").get(0).asText())
+        com.fasterxml.jackson.databind.JsonNode firstError = errorJson.get("error").get("errors").get(0);
+        assertThat(firstError.get("message").asText())
                 .contains("Schema for table public.evolution_bad is incompatible with an earlier schema for subject");
+        String oldSchema = firstError.get("old_schema").asText();
+        String newSchema = firstError.get("new_schema").asText();
+        assertThat(oldSchema).contains("evolution_bad").doesNotContain("required_flag");
+        assertThat(newSchema).contains("evolution_bad").contains("required_flag");
     }
 
     private static Configuration buildConfig() {

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -105,7 +105,8 @@ class RegisterSchemasHandlerTest {
     void schemaIncompatibilityReturns409() throws Exception {
         HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
         setupSchemaReaderAndConverter();
-        doThrow(new SchemaIncompatibilityException("incompatible schema", new Exception()))
+        doThrow(new SchemaIncompatibilityException("incompatible schema", new Exception(),
+                "{\"old\":true}", "{\"new\":true}"))
                 .when(publisher).register(any(), any(), any());
 
         handler.handle(exchange);
@@ -115,16 +116,21 @@ class RegisterSchemasHandlerTest {
         assertThat(response.get("error").get("message").asText())
                 .isEqualTo("One or more schemas are incompatible with an existing version");
         assertThat(response.get("error").get("errors")).hasSize(1);
-        assertThat(response.get("error").get("errors").get(0).asText()).contains("incompatible schema");
+        JsonNode error = response.get("error").get("errors").get(0);
+        assertThat(error.get("message").asText()).contains("incompatible schema");
+        assertThat(error.get("old_schema").asText()).isEqualTo("{\"old\":true}");
+        assertThat(error.get("new_schema").asText()).isEqualTo("{\"new\":true}");
     }
 
     @Test
     void multipleSchemaIncompatibilitiesReturnsAllErrors() throws Exception {
         HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\",\"public.orders\"]}");
         setupSchemaReaderAndConverterForTables();
-        doThrow(new SchemaIncompatibilityException("incompatible schema for users", new Exception()))
+        doThrow(new SchemaIncompatibilityException("incompatible schema for users", new Exception(),
+                "{\"old\":\"users\"}", "{\"new\":\"users\"}"))
                 .when(publisher).register(eq("public.users"), any(), any());
-        doThrow(new SchemaIncompatibilityException("incompatible schema for orders", new Exception()))
+        doThrow(new SchemaIncompatibilityException("incompatible schema for orders", new Exception(),
+                "{\"old\":\"orders\"}", "{\"new\":\"orders\"}"))
                 .when(publisher).register(eq("public.orders"), any(), any());
 
         handler.handle(exchange);
@@ -133,8 +139,10 @@ class RegisterSchemasHandlerTest {
         JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
         JsonNode errors = response.get("error").get("errors");
         assertThat(errors).hasSize(2);
-        assertThat(errors.get(0).asText()).contains("incompatible schema for users");
-        assertThat(errors.get(1).asText()).contains("incompatible schema for orders");
+        assertThat(errors.get(0).get("message").asText()).contains("incompatible schema for users");
+        assertThat(errors.get(0).get("old_schema").asText()).isEqualTo("{\"old\":\"users\"}");
+        assertThat(errors.get(1).get("message").asText()).contains("incompatible schema for orders");
+        assertThat(errors.get(1).get("old_schema").asText()).isEqualTo("{\"old\":\"orders\"}");
     }
 
     @Test

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -141,8 +141,10 @@ class RegisterSchemasHandlerTest {
         assertThat(errors).hasSize(2);
         assertThat(errors.get(0).get("message").asText()).contains("incompatible schema for users");
         assertThat(errors.get(0).get("old_schema").asText()).isEqualTo("{\"old\":\"users\"}");
+        assertThat(errors.get(0).get("new_schema").asText()).isEqualTo("{\"new\":\"users\"}");
         assertThat(errors.get(1).get("message").asText()).contains("incompatible schema for orders");
         assertThat(errors.get(1).get("old_schema").asText()).isEqualTo("{\"old\":\"orders\"}");
+        assertThat(errors.get(1).get("new_schema").asText()).isEqualTo("{\"new\":\"orders\"}");
     }
 
     @Test

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
@@ -45,13 +45,20 @@ class SchemaRegistryPublisherTest {
         try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
             when(client.register(any(), any(ParsedSchema.class)))
                     .thenThrow(new RestClientException("Schema being registered is incompatible", 409, 409));
+            when(client.getLatestSchemaMetadata(any()))
+                    .thenReturn(new SchemaMetadata(1, 1, "\"string\""));
         })) {
             SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
 
             assertThatThrownBy(() -> publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA))
                     .isInstanceOf(SchemaIncompatibilityException.class)
                     .hasMessageContaining("public.users")
-                    .hasMessageContaining("test.public.users-value");
+                    .hasMessageContaining("test.public.users-value")
+                    .satisfies(ex -> {
+                        SchemaIncompatibilityException sie = (SchemaIncompatibilityException) ex;
+                        assertThat(sie.getOldSchema()).isEqualTo("\"string\"");
+                        assertThat(sie.getNewSchema()).isEqualTo(AVRO_SCHEMA.toString());
+                    });
         }
     }
 

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
@@ -63,6 +63,27 @@ class SchemaRegistryPublisherTest {
     }
 
     @Test
+    void register409WithFetchFailureIncludesReasonInMessage() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.register(any(), any(ParsedSchema.class)))
+                    .thenThrow(new RestClientException("Schema being registered is incompatible", 409, 409));
+            when(client.getLatestSchemaMetadata(any()))
+                    .thenThrow(new IOException("connection refused"));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            assertThatThrownBy(() -> publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA))
+                    .isInstanceOf(SchemaIncompatibilityException.class)
+                    .hasMessageContaining("could not retrieve existing schema: connection refused")
+                    .satisfies(ex -> {
+                        SchemaIncompatibilityException sie = (SchemaIncompatibilityException) ex;
+                        assertThat(sie.getOldSchema()).isNull();
+                        assertThat(sie.getNewSchema()).isEqualTo(AVRO_SCHEMA.toString());
+                    });
+        }
+    }
+
+    @Test
     void registerNon409RestClientExceptionThrowsIOException() throws Exception {
         try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
             when(client.register(any(), any(ParsedSchema.class)))

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
@@ -74,10 +74,9 @@ class SchemaRegistryPublisherTest {
 
             assertThatThrownBy(() -> publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA))
                     .isInstanceOf(SchemaIncompatibilityException.class)
-                    .hasMessageContaining("could not retrieve existing schema: connection refused")
                     .satisfies(ex -> {
                         SchemaIncompatibilityException sie = (SchemaIncompatibilityException) ex;
-                        assertThat(sie.getOldSchema()).isNull();
+                        assertThat(sie.getOldSchema()).isEqualTo("could not retrieve existing schema: connection refused");
                         assertThat(sie.getNewSchema()).isEqualTo(AVRO_SCHEMA.toString());
                     });
         }


### PR DESCRIPTION
## Summary
This PR enriches the 409 error response from the schema translator with the existing (old) schema from the registry and the attempted (new) schema, so callers can immediately understand what changed and caused the incompatibility.

Previously the error only contained a plain message string. Now each entry in `errors` is a structured object:

```json
{
  "error": {
    "message": "One or more schemas are incompatible with an existing version",
    "errors": [
      {
        "message": "Schema for table public.users is incompatible...",
        "old_schema": "{...avro schema json...}",
        "new_schema": "{...avro schema json...}"
      }
    ]
  }
}
```

In case the `old_schema` fails to be fetched from the Schema Registry (either because it doesn't exist or due to an Schema Registry error), the `old_schema` will display an error: `"could not retrieve existing schema: " + fetchEx.getMessage();`

## Testing
All new, old and modified tests pass locally