### PR TITLE
[MARS-5721] Create DELETE schemas endpoint

### DIFF
--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
@@ -1,6 +1,7 @@
 package io.debezium.schematranslator;
 
 import com.sun.net.httpserver.HttpServer;
+import io.debezium.schematranslator.api.DeleteSchemasHandler;
 import io.debezium.schematranslator.api.HealthHandler;
 import io.debezium.schematranslator.api.RegisterSchemasHandler;
 import io.debezium.schematranslator.config.TranslatorConfig;
@@ -12,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 
 /**
@@ -33,9 +35,23 @@ public class App {
 
         // Start HTTP server
         HttpServer server = HttpServer.create(new InetSocketAddress(config.getHttpPort()), 0);
-        server.createContext(
-                "/api/v1/schema-translator/schemas",
-                new RegisterSchemasHandler(schemaReader, avroConverter, publisher));
+        RegisterSchemasHandler registerHandler = new RegisterSchemasHandler(schemaReader, avroConverter, publisher);
+        DeleteSchemasHandler deleteHandler = new DeleteSchemasHandler(publisher, config.getTopicPrefix());
+        server.createContext("/api/v1/schema-translator/schemas", exchange -> {
+            String method = exchange.getRequestMethod();
+            if ("POST".equalsIgnoreCase(method)) {
+                registerHandler.handle(exchange);
+            } else if ("DELETE".equalsIgnoreCase(method)) {
+                deleteHandler.handle(exchange);
+            } else {
+                byte[] body = "{\"error\":{\"message\":\"Method not allowed\"}}".getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(405, body.length);
+                try (var out = exchange.getResponseBody()) {
+                    out.write(body);
+                }
+            }
+        });
         server.createContext(
                 "/api/v1/schema-translator/health",
                 new HealthHandler());

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/DeleteSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/DeleteSchemasHandler.java
@@ -1,0 +1,76 @@
+package io.debezium.schematranslator.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import io.debezium.schematranslator.model.ErrorResponse;
+import io.debezium.schematranslator.model.RegisteredSchema;
+import io.debezium.schematranslator.model.SchemaDeletionResponse;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handles DELETE /api/v1/schema-translator/schemas.
+ */
+public class DeleteSchemasHandler implements HttpHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteSchemasHandler.class);
+
+    private final ObjectMapper objectMapper;
+    private final SchemaRegistryPublisher publisher;
+    private final String topicPrefix;
+
+    public DeleteSchemasHandler(SchemaRegistryPublisher publisher, String topicPrefix) {
+        this.objectMapper = new ObjectMapper();
+        this.publisher = publisher;
+        this.topicPrefix = topicPrefix;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (!"DELETE".equalsIgnoreCase(exchange.getRequestMethod())) {
+            sendJson(exchange, 405, new ErrorResponse("Method not allowed"));
+            return;
+        }
+
+        List<String> subjects;
+        try {
+            subjects = publisher.getAllSubjects();
+        }
+        catch (IOException e) {
+            LOGGER.error("Failed to retrieve subjects from Schema Registry", e);
+            sendJson(exchange, 500, new ErrorResponse("Could not connect to the Schema Registry"));
+            return;
+        }
+
+        List<RegisteredSchema> deletedSchemas = new ArrayList<>();
+        for (String subject : subjects) {
+            try {
+                deletedSchemas.add(publisher.deleteSubject(subject, topicPrefix));
+            }
+            catch (IOException e) {
+                LOGGER.error("Failed to delete subject '{}'", subject, e);
+                sendJson(exchange, 500, new ErrorResponse("Failed to delete schemas from schema registry"));
+                return;
+            }
+        }
+
+        LOGGER.info("Deleted {} subject(s) from Schema Registry", deletedSchemas.size());
+        sendJson(exchange, 200, new SchemaDeletionResponse(deletedSchemas));
+    }
+
+    private void sendJson(HttpExchange exchange, int statusCode, Object body) throws IOException {
+        byte[] responseBytes = objectMapper.writeValueAsBytes(body);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, responseBytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(responseBytes);
+        }
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaDeletionResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaDeletionResponse.java
@@ -1,0 +1,30 @@
+package io.debezium.schematranslator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Response body for DELETE /api/v1/schema-translator/schemas.
+ */
+public class SchemaDeletionResponse {
+
+    @JsonProperty("deleted_schemas")
+    private List<RegisteredSchema> deletedSchemas;
+
+    @JsonProperty("deleted_count")
+    private int deletedCount;
+
+    public SchemaDeletionResponse(List<RegisteredSchema> deletedSchemas) {
+        this.deletedSchemas = deletedSchemas;
+        this.deletedCount = deletedSchemas.size();
+    }
+
+    public List<RegisteredSchema> getDeletedSchemas() {
+        return deletedSchemas;
+    }
+
+    public int getDeletedCount() {
+        return deletedCount;
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -11,7 +11,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Registers Avro schemas with the Confluent Schema Registry.
@@ -65,6 +67,61 @@ public class SchemaRegistryPublisher {
             }
             throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Returns all subject names currently registered in the Schema Registry.
+     *
+     * @return list of subject names
+     * @throws IOException if a network or infrastructure error occurs
+     */
+    public List<String> getAllSubjects() throws IOException {
+        try {
+            return new ArrayList<>(client.getAllSubjects());
+        }
+        catch (RestClientException e) {
+            throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Deletes all versions of the given subject from the Schema Registry.
+     *
+     * @param subject     the SR subject to delete
+     * @param topicPrefix the topic prefix used to derive the table name
+     * @return a {@link RegisteredSchema} describing the deleted subject
+     * @throws IOException if a network or infrastructure error occurs
+     */
+    public RegisteredSchema deleteSubject(String subject, String topicPrefix) throws IOException {
+        try {
+            SchemaMetadata metadata = client.getLatestSchemaMetadata(subject);
+            int schemaId = metadata.getId();
+            int version = metadata.getVersion();
+            client.deleteSubject(subject);
+            String table = deriveTableName(subject, topicPrefix);
+            LOGGER.info("Deleted subject '{}' (table '{}', schema_id={}, version={})",
+                    subject, table, schemaId, version);
+            return new RegisteredSchema(table, subject, schemaId, version);
+        }
+        catch (RestClientException e) {
+            throw new IOException("Schema Registry error (HTTP " + e.getStatus() + "): " + e.getMessage(), e);
+        }
+    }
+
+    private static String deriveTableName(String subject, String topicPrefix) {
+        String table = subject;
+        if (topicPrefix != null && !topicPrefix.isEmpty()) {
+            String prefix = topicPrefix + ".";
+            if (table.startsWith(prefix)) {
+                table = table.substring(prefix.length());
+            }
+        }
+        if (table.endsWith("-value")) {
+            table = table.substring(0, table.length() - "-value".length());
+        } else if (table.endsWith("-key")) {
+            table = table.substring(0, table.length() - "-key".length());
+        }
+        return table;
     }
 
     /**

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/SchemaRegistryPublisher.java
@@ -94,6 +94,8 @@ public class SchemaRegistryPublisher {
      */
     public RegisteredSchema deleteSubject(String subject, String topicPrefix) throws IOException {
         try {
+            // Capture metadata before deletion — getLatestSchemaMetadata must precede deleteSubject
+            // intentionally, as it would throw 404 afterwards.
             SchemaMetadata metadata = client.getLatestSchemaMetadata(subject);
             int schemaId = metadata.getId();
             int version = metadata.getVersion();

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/DeleteSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/DeleteSchemasHandlerTest.java
@@ -1,0 +1,126 @@
+package io.debezium.schematranslator.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import io.debezium.schematranslator.model.RegisteredSchema;
+import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteSchemasHandlerTest {
+
+    @Mock
+    private SchemaRegistryPublisher publisher;
+
+    private DeleteSchemasHandler handler;
+    private ByteArrayOutputStream responseBody;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        handler = new DeleteSchemasHandler(publisher, "test");
+    }
+
+    @Test
+    void nonDeleteMethodReturns405() throws Exception {
+        HttpExchange exchange = mockExchange("GET");
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(405), anyLong());
+    }
+
+    @Test
+    void getAllSubjectsFailureReturns500WithConnectMessage() throws Exception {
+        HttpExchange exchange = mockExchange("DELETE");
+        when(publisher.getAllSubjects()).thenThrow(new IOException("connection refused"));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(500), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText())
+                .isEqualTo("Could not connect to the Schema Registry");
+    }
+
+    @Test
+    void deleteSubjectFailureReturns500WithDeleteMessage() throws Exception {
+        HttpExchange exchange = mockExchange("DELETE");
+        when(publisher.getAllSubjects()).thenReturn(List.of("test.public.users-value"));
+        when(publisher.deleteSubject("test.public.users-value", "test"))
+                .thenThrow(new IOException("delete failed"));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(500), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText())
+                .isEqualTo("Failed to delete schemas from schema registry");
+    }
+
+    @Test
+    void successfulDeletionReturns200WithDeletedSchemas() throws Exception {
+        HttpExchange exchange = mockExchange("DELETE");
+        when(publisher.getAllSubjects())
+                .thenReturn(List.of("test.public.users-value", "test.public.users-key"));
+        when(publisher.deleteSubject("test.public.users-value", "test"))
+                .thenReturn(new RegisteredSchema("public.users", "test.public.users-value", 1, 1));
+        when(publisher.deleteSubject("test.public.users-key", "test"))
+                .thenReturn(new RegisteredSchema("public.users", "test.public.users-key", 2, 1));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(200), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("deleted_count").asInt()).isEqualTo(2);
+        assertThat(response.get("deleted_schemas")).hasSize(2);
+        JsonNode first = response.get("deleted_schemas").get(0);
+        assertThat(first.get("subject").asText()).isEqualTo("test.public.users-value");
+        assertThat(first.get("table").asText()).isEqualTo("public.users");
+        assertThat(first.get("schema_id").asInt()).isEqualTo(1);
+        assertThat(first.get("version").asInt()).isEqualTo(1);
+        JsonNode second = response.get("deleted_schemas").get(1);
+        assertThat(second.get("subject").asText()).isEqualTo("test.public.users-key");
+        assertThat(second.get("table").asText()).isEqualTo("public.users");
+        assertThat(second.get("schema_id").asInt()).isEqualTo(2);
+        assertThat(second.get("version").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    void emptyRegistryReturns200WithEmptyArrayAndZeroCount() throws Exception {
+        HttpExchange exchange = mockExchange("DELETE");
+        when(publisher.getAllSubjects()).thenReturn(List.of());
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(200), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("deleted_count").asInt()).isEqualTo(0);
+        assertThat(response.get("deleted_schemas")).hasSize(0);
+    }
+
+    private HttpExchange mockExchange(String method) throws IOException {
+        HttpExchange exchange = mock(HttpExchange.class);
+        when(exchange.getRequestMethod()).thenReturn(method);
+        when(exchange.getResponseHeaders()).thenReturn(new Headers());
+        responseBody = new ByteArrayOutputStream();
+        when(exchange.getResponseBody()).thenReturn(responseBody);
+        return exchange;
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -75,6 +75,11 @@ class RegisterSchemasHandlerIT {
         reader = new DebeziumSchemaReader(buildConfig());
         String srUrl = "http://localhost:" + schemaRegistry.getMappedPort(8081);
         SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(srUrl);
+
+        // Ensure the registry is clean before each test
+        for (String subject : publisher.getAllSubjects()) {
+            publisher.deleteSubject(subject, "test");
+        }
         RegisterSchemasHandler registerHandler = new RegisterSchemasHandler(reader, new AvroSchemaConverter(), publisher);
         DeleteSchemasHandler deleteHandler = new DeleteSchemasHandler(publisher, "test");
 
@@ -199,7 +204,7 @@ class RegisterSchemasHandlerIT {
         com.fasterxml.jackson.databind.JsonNode json =
                 new com.fasterxml.jackson.databind.ObjectMapper().readTree(body);
         int deletedCount = json.get("deleted_count").asInt();
-        assertThat(deletedCount).isGreaterThanOrEqualTo(2);
+        assertThat(deletedCount).isEqualTo(2);
         assertThat(json.get("deleted_schemas")).hasSize(deletedCount);
         // Verify table name, schema_id, and version for the registered subjects
         com.fasterxml.jackson.databind.JsonNode deletedSchemas = json.get("deleted_schemas");

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -75,10 +75,21 @@ class RegisterSchemasHandlerIT {
         reader = new DebeziumSchemaReader(buildConfig());
         String srUrl = "http://localhost:" + schemaRegistry.getMappedPort(8081);
         SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(srUrl);
-        RegisterSchemasHandler handler = new RegisterSchemasHandler(reader, new AvroSchemaConverter(), publisher);
+        RegisterSchemasHandler registerHandler = new RegisterSchemasHandler(reader, new AvroSchemaConverter(), publisher);
+        DeleteSchemasHandler deleteHandler = new DeleteSchemasHandler(publisher, "test");
 
         handlerServer = HttpServer.create(new InetSocketAddress(0), 0);
-        handlerServer.createContext("/api/v1/schema-translator/schemas", handler);
+        handlerServer.createContext("/api/v1/schema-translator/schemas", exchange -> {
+            String method = exchange.getRequestMethod();
+            if ("POST".equalsIgnoreCase(method)) {
+                registerHandler.handle(exchange);
+            } else if ("DELETE".equalsIgnoreCase(method)) {
+                deleteHandler.handle(exchange);
+            } else {
+                exchange.sendResponseHeaders(405, -1);
+                exchange.getResponseBody().close();
+            }
+        });
         handlerServer.start();
         handlerPort = handlerServer.getAddress().getPort();
     }
@@ -170,6 +181,46 @@ class RegisterSchemasHandlerIT {
         assertThat(newSchema).contains("evolution_bad").contains("required_flag");
     }
 
+    @Test
+    void deleteAllSchemasReturns200WithDeletedSchemas() throws Exception {
+        execute("CREATE TABLE IF NOT EXISTS public.delete_test (" +
+                "  id SERIAL PRIMARY KEY," +
+                "  label TEXT NOT NULL" +
+                ")");
+
+        HttpURLConnection postConn = post("{\"tables\":[\"public.delete_test\"]}");
+        assertThat(postConn.getResponseCode()).isEqualTo(200);
+        postConn.getInputStream().readAllBytes(); // drain
+
+        HttpURLConnection deleteConn = delete();
+        String body = new String(deleteConn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(deleteConn.getResponseCode()).isEqualTo(200);
+        com.fasterxml.jackson.databind.JsonNode json =
+                new com.fasterxml.jackson.databind.ObjectMapper().readTree(body);
+        int deletedCount = json.get("deleted_count").asInt();
+        assertThat(deletedCount).isGreaterThanOrEqualTo(2);
+        assertThat(json.get("deleted_schemas")).hasSize(deletedCount);
+        // Verify table name, schema_id, and version for the registered subjects
+        com.fasterxml.jackson.databind.JsonNode deletedSchemas = json.get("deleted_schemas");
+        for (com.fasterxml.jackson.databind.JsonNode schema : deletedSchemas) {
+            String subject = schema.get("subject").asText();
+            if (subject.equals("test.public.delete_test-value") || subject.equals("test.public.delete_test-key")) {
+                assertThat(schema.get("table").asText()).isEqualTo("public.delete_test");
+                assertThat(schema.get("schema_id").asInt()).isGreaterThan(0);
+                assertThat(schema.get("version").asInt()).isEqualTo(1);
+            }
+        }
+
+        // Verify the registry is actually empty now
+        HttpURLConnection deleteAgain = delete();
+        String emptyBody = new String(deleteAgain.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        com.fasterxml.jackson.databind.JsonNode emptyJson =
+                new com.fasterxml.jackson.databind.ObjectMapper().readTree(emptyBody);
+        assertThat(deleteAgain.getResponseCode()).isEqualTo(200);
+        assertThat(emptyJson.get("deleted_count").asInt()).isEqualTo(0);
+    }
+
     private static Configuration buildConfig() {
         Properties props = new Properties();
         props.put("database.hostname", postgres.getHost());
@@ -195,6 +246,14 @@ class RegisterSchemasHandlerIT {
         byte[] bytes = jsonBody.getBytes(StandardCharsets.UTF_8);
         conn.getOutputStream().write(bytes);
         conn.getOutputStream().flush();
+        return conn;
+    }
+
+    private HttpURLConnection delete() throws Exception {
+        URL url = new URL("http://localhost:" + handlerPort
+                + "/api/v1/schema-translator/schemas");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("DELETE");
         return conn;
     }
 

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -17,6 +17,10 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -172,12 +176,12 @@ class RegisterSchemasHandlerIT {
 
         HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_bad\"]}");
         assertThat(conn2.getResponseCode()).isEqualTo(409);
-        java.io.InputStream errStream = conn2.getErrorStream();
+        InputStream errStream = conn2.getErrorStream();
         String errorBody = errStream != null ? new String(errStream.readAllBytes(), StandardCharsets.UTF_8) : "";
-        com.fasterxml.jackson.databind.JsonNode errorJson = new com.fasterxml.jackson.databind.ObjectMapper().readTree(errorBody);
+        JsonNode errorJson = new ObjectMapper().readTree(errorBody);
         assertThat(errorJson.get("error").get("message").asText())
                 .isEqualTo("One or more schemas are incompatible with an existing version");
-        com.fasterxml.jackson.databind.JsonNode firstError = errorJson.get("error").get("errors").get(0);
+        JsonNode firstError = errorJson.get("error").get("errors").get(0);
         assertThat(firstError.get("message").asText())
                 .contains("Schema for table public.evolution_bad is incompatible with an earlier schema for subject");
         String oldSchema = firstError.get("old_schema").asText();
@@ -201,14 +205,13 @@ class RegisterSchemasHandlerIT {
         String body = new String(deleteConn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
         assertThat(deleteConn.getResponseCode()).isEqualTo(200);
-        com.fasterxml.jackson.databind.JsonNode json =
-                new com.fasterxml.jackson.databind.ObjectMapper().readTree(body);
+        JsonNode json = new ObjectMapper().readTree(body);
         int deletedCount = json.get("deleted_count").asInt();
         assertThat(deletedCount).isEqualTo(2);
         assertThat(json.get("deleted_schemas")).hasSize(deletedCount);
         // Verify table name, schema_id, and version for the registered subjects
-        com.fasterxml.jackson.databind.JsonNode deletedSchemas = json.get("deleted_schemas");
-        for (com.fasterxml.jackson.databind.JsonNode schema : deletedSchemas) {
+        JsonNode deletedSchemas = json.get("deleted_schemas");
+        for (JsonNode schema : deletedSchemas) {
             String subject = schema.get("subject").asText();
             if (subject.equals("test.public.delete_test-value") || subject.equals("test.public.delete_test-key")) {
                 assertThat(schema.get("table").asText()).isEqualTo("public.delete_test");
@@ -220,8 +223,7 @@ class RegisterSchemasHandlerIT {
         // Verify the registry is actually empty now
         HttpURLConnection deleteAgain = delete();
         String emptyBody = new String(deleteAgain.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        com.fasterxml.jackson.databind.JsonNode emptyJson =
-                new com.fasterxml.jackson.databind.ObjectMapper().readTree(emptyBody);
+        JsonNode emptyJson = new ObjectMapper().readTree(emptyBody);
         assertThat(deleteAgain.getResponseCode()).isEqualTo(200);
         assertThat(emptyJson.get("deleted_count").asInt()).isEqualTo(0);
     }

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/SchemaRegistryPublisherTest.java
@@ -10,6 +10,7 @@ import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -93,6 +94,64 @@ class SchemaRegistryPublisherTest {
             assertThatThrownBy(() -> publisher.register("public.users", "test.public.users-value", AVRO_SCHEMA))
                     .isInstanceOf(IOException.class)
                     .hasMessageContaining("HTTP 500");
+        }
+    }
+
+    @Test
+    void getAllSubjectsReturnsSubjectList() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.getAllSubjects()).thenReturn(List.of("test.public.users-value", "test.public.users-key"));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            List<String> subjects = publisher.getAllSubjects();
+
+            assertThat(subjects).containsExactlyInAnyOrder("test.public.users-value", "test.public.users-key");
+        }
+    }
+
+    @Test
+    void getAllSubjectsWrapsRestClientExceptionIntoIOException() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.getAllSubjects()).thenThrow(new RestClientException("Unauthorized", 401, 40101));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            assertThatThrownBy(() -> publisher.getAllSubjects())
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("HTTP 401");
+        }
+    }
+
+    @Test
+    void deleteSubjectReturnsCorrectRegisteredSchema() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.getLatestSchemaMetadata("test.public.users-value"))
+                    .thenReturn(new SchemaMetadata(42, 3, "{}"));
+            when(client.deleteSubject("test.public.users-value")).thenReturn(List.of(1, 2, 3));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            RegisteredSchema result = publisher.deleteSubject("test.public.users-value", "test");
+
+            assertThat(result.getTable()).isEqualTo("public.users");
+            assertThat(result.getSubject()).isEqualTo("test.public.users-value");
+            assertThat(result.getSchemaId()).isEqualTo(42);
+            assertThat(result.getVersion()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void deleteSubjectWrapsRestClientExceptionIntoIOException() throws Exception {
+        try (var mock = mockConstruction(CachedSchemaRegistryClient.class, (client, ctx) -> {
+            when(client.getLatestSchemaMetadata(any()))
+                    .thenThrow(new RestClientException("Subject not found", 404, 40401));
+        })) {
+            SchemaRegistryPublisher publisher = new SchemaRegistryPublisher("http://localhost:8081");
+
+            assertThatThrownBy(() -> publisher.deleteSubject("test.public.users-value", "test"))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("HTTP 404");
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a `DELETE` operation to the `/api/v1/schema-translator/schemas` endpoint that removes all subjects currently registered in the Confluent Schema Registry. This will be used to clean up the Schema Registry for dual prod/staging PRs.

## API Specification

### `DELETE /api/v1/schema-translator/schemas`

Deletes all subjects currently registered in the Confluent Schema Registry.

#### Request

No request body.

#### Response

**`200 OK`**
```json
{
  "deleted_schemas": [
    {
      "table":     "public.users",
      "subject":   "test.public.users-value",
      "schema_id": 101,
      "version":   1
    },
    {
      "table":     "public.users",
      "subject":   "test.public.users-key",
      "schema_id": 102,
      "version":   1
    }
  ],
  "deleted_count": 2
}
```

Each entry reflects the last registered version of that subject before deletion. `deleted_count` equals `len(deleted_schemas)`. If the registry is empty, both fields are `0` / `[]`.

The `table` name is derived by stripping the topic prefix and the `-value`/`-key` suffix from the subject (e.g. `test.public.users-value` → `public.users`). `schema_id` and `version` are captured from `getLatestSchemaMetadata` before the subject is deleted.

#### Errors

**`500 Internal Server Error`** — cannot reach Schema Registry
```json
{
  "error": { "message": "Could not connect to the Schema Registry" }
}
```

**`500 Internal Server Error`** — deletion failed mid-way
```json
{
  "error": { "message": "Failed to delete schemas from schema registry" }
}
```

**`405 Method Not Allowed`**
```json
{
  "error": { "message": "Method not allowed" }
}
```

## Testing

**Unit tests — `DeleteSchemasHandlerTest`**
- Non-DELETE method returns 405
- `getAllSubjects()` failure returns 500 with `"Could not connect to the Schema Registry"`
- `deleteSubject()` failure returns 500 with `"Failed to delete schemas from schema registry"`
- Successful deletion returns 200 with correct `deleted_schemas` (subject, table, schema_id, version) and `deleted_count`
- Empty registry returns 200 with empty array and `deleted_count: 0`

**Unit tests — `SchemaRegistryPublisherTest`**
- `getAllSubjects()` returns the subject list from the client
- `getAllSubjects()` wraps `RestClientException` into `IOException`
- `deleteSubject()` returns a `RegisteredSchema` with the correct table, subject, schema_id, and version
- `deleteSubject()` wraps `RestClientException` into `IOException`

**Integration test — `RegisterSchemasHandlerIT`**

Reuses the existing Testcontainers setup (PostgreSQL + Kafka + Schema Registry). Registers a table via `POST`, calls `DELETE`, and verifies:
- Response is `200` with `deleted_count = 2`
- The `delete_test` subjects carry the correct `table`, a positive `schema_id`, and `version: 1`
- A second `DELETE` call returns `deleted_count: 0`, confirming the registry is actually empty