### PR TITLE
[MaRS] debezium-schema-translator POST to provide connection_string

### DIFF
--- a/debezium-schema-translator/README.md
+++ b/debezium-schema-translator/README.md
@@ -20,16 +20,12 @@ Subject names follow Debezium's topic naming convention:
 
 ## Configuration
 
-All configuration is done via environment variables.
+Service-level configuration is done via environment variables. Postgres connection details are
+not part of the service config — they are supplied per request via the `connection_string` field
+in the request body.
 
 | Variable              | Default                    | Required | Description                                          |
 |-----------------------|----------------------------|----------|------------------------------------------------------|
-| `POSTGRES_HOST`       | `localhost`                |          | Postgres hostname                                  |
-| `POSTGRES_PORT`       | `5432`                     |          | Postgres port                                      |
-| `POSTGRES_DATABASE`   |                            | Yes      | Postgres database name                             |
-| `POSTGRES_USER`       | `postgres`                 |          | Postgres user                                      |
-| `POSTGRES_PASSWORD`   |                            | Yes      | Postgres password                                  |
-| `POSTGRES_SSL_MODE`   | `prefer`                   |          | SSL mode (`disable`, `prefer`, `require`, etc.)      |
 | `SCHEMA_REGISTRY_URL` | `http://localhost:8081`    |          | Confluent Schema Registry URL                        |
 | `TOPIC_PREFIX`        |                            | Yes      | Debezium topic prefix, used to derive subject names  |
 | `HTTP_PORT`           | `8080`                     |          | Port the HTTP server listens on                      |
@@ -57,11 +53,17 @@ Content-Type: application/json
 
 ```json
 {
-  "tables": ["public.users", "orders", "myschema.events"]
+  "tables": ["public.users", "orders", "myschema.events"],
+  "connection_string": "postgresql://user:password@host:5432/dbname"
 }
 ```
 
 Table names can be `schema.table` or just `table` (defaults to `public` schema).
+
+The `connection_string` is a Postgres URL of the form
+`postgresql://user:password@host:port/dbname[?sslmode=...]`. A new Postgres connection is opened
+for every request and closed before responding, so each call can target a different database.
+When omitted, the SSL mode defaults to `prefer`.
 
 **Success response (200):**
 
@@ -86,12 +88,12 @@ Table names can be `schema.table` or just `table` (defaults to `public` schema).
 
 **Error responses:**
 
-| Code | Cause                                                     |
-|------|-----------------------------------------------------------|
-| 400  | Invalid request body or missing `tables` field            |
-| 405  | Wrong HTTP method                                         |
-| 409  | Schema incompatible with an already-registered version    |
-| 500  | Postgres read error or Schema Registry error            |
+| Code | Cause                                                              |
+|------|--------------------------------------------------------------------|
+| 400  | Invalid request body, missing `tables`, or missing/malformed `connection_string` |
+| 405  | Wrong HTTP method                                                  |
+| 409  | Schema incompatible with an already-registered version             |
+| 500  | Postgres read error or Schema Registry error                       |
 
 Registration is idempotent: registering an identical schema multiple times returns the same schema ID and version.
 
@@ -127,7 +129,10 @@ curl -s http://localhost:8080/api/v1/schema-translator/health
 # (replace "public.my_table" with an actual table in your database)
 curl -s -X POST http://localhost:8080/api/v1/schema-translator/schemas \
   -H 'Content-Type: application/json' \
-  -d '{"tables": ["public.my_table"]}'
+  -d '{
+        "tables": ["public.my_table"],
+        "connection_string": "postgresql://postgres:postgres@postgres:5432/testdb"
+      }'
 
 # Inspect registered subjects in Schema Registry
 curl -s http://localhost:8081/subjects

--- a/debezium-schema-translator/docker-compose.yml
+++ b/debezium-schema-translator/docker-compose.yml
@@ -12,7 +12,10 @@ version: "3.8"
 #   curl -s http://localhost:8080/api/v1/schema-translator/health
 #   curl -s -X POST http://localhost:8080/api/v1/schema-translator/schemas \
 #     -H 'Content-Type: application/json' \
-#     -d '{"tables": ["public.users"]}'
+#     -d '{
+#           "tables": ["public.users"],
+#           "connection_string": "postgresql://postgres:postgres@postgres:5432/testdb"
+#         }'
 #
 # Inspect registered schemas:
 #   curl -s http://localhost:8081/subjects
@@ -81,8 +84,5 @@ services:
       - ./target:/app
     entrypoint: ["sh", "-c", "java -jar /app/debezium-schema-translator-*-shaded.jar"]
     environment:
-      POSTGRES_HOST: postgres
-      POSTGRES_DATABASE: testdb
-      POSTGRES_PASSWORD: postgres
       TOPIC_PREFIX: test
       SCHEMA_REGISTRY_URL: http://schema-registry:8081

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/App.java
@@ -29,7 +29,7 @@ public class App {
         LOGGER.info("Starting Debezium Schema Translator on port {}", config.getHttpPort());
 
         // Initialise core components
-        DebeziumSchemaReader schemaReader = new DebeziumSchemaReader(config.toDebeziumConfig());
+        DebeziumSchemaReader schemaReader = new DebeziumSchemaReader(config.getTopicPrefix());
         AvroSchemaConverter avroConverter = new AvroSchemaConverter();
         SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(config.getSchemaRegistryUrl());
 
@@ -60,16 +60,10 @@ public class App {
 
         LOGGER.info("Debezium Schema Translator is running on port {}", config.getHttpPort());
 
-        // Register shutdown hook to stop the HTTP server and close the JDBC connection cleanly
+        // Register shutdown hook to stop the HTTP server cleanly
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             LOGGER.info("Shutting down...");
             server.stop(0);
-            try {
-                schemaReader.close();
-            }
-            catch (Exception e) {
-                LOGGER.warn("Error during shutdown", e);
-            }
         }));
     }
 }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -68,13 +68,26 @@ public class RegisterSchemasHandler implements HttpHandler {
             return;
         }
 
+        // Validate connection_string field
+        String connectionString = request.getConnectionString();
+        if (connectionString == null || connectionString.isBlank()) {
+            sendJson(exchange, 400,
+                    new ErrorResponse("Field 'connection_string' is required"));
+            return;
+        }
+
         List<String> tables = request.getTables();
         LOGGER.info("Processing schemas request for {} table(s): {}", tables.size(), tables);
 
         // Read schemas from Postgres
         Map<TableId, TableSchema> tableSchemas;
         try {
-            tableSchemas = schemaReader.readSchemas(tables);
+            tableSchemas = schemaReader.readSchemas(connectionString, tables);
+        }
+        catch (IllegalArgumentException e) {
+            LOGGER.warn("Invalid request: {}", e.getMessage());
+            sendJson(exchange, 400, new ErrorResponse(e.getMessage()));
+            return;
         }
         catch (Exception e) {
             LOGGER.error("Failed to read schemas from Postgres", e);

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/config/TranslatorConfig.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/config/TranslatorConfig.java
@@ -1,73 +1,20 @@
 package io.debezium.schematranslator.config;
 
-import io.debezium.config.Configuration;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
 /**
- * Configuration loaded from environment variables.
- * Provides independent config groups for Postgres and Schema Registry.
+ * Service-level configuration loaded from environment variables.
+ * Postgres connection details are not part of this config — they are supplied per-request
+ * by the caller via the {@code connection_string} field in the request body.
  */
 public class TranslatorConfig {
 
-    // Postgres connection settings
-    private final String postgresHost;
-    private final int postgresPort;
-    private final String postgresDatabase;
-    private final String postgresUser;
-    private final String postgresPassword;
-    private final String postgresSslMode;
-
-    // Schema Registry settings
     private final String schemaRegistryUrl;
-
-    // Service settings
     private final String topicPrefix;
     private final int httpPort;
 
     public TranslatorConfig() {
-        this.postgresHost = getEnv("POSTGRES_HOST", "localhost");
-        this.postgresPort = Integer.parseInt(getEnv("POSTGRES_PORT", "5432"));
-        this.postgresDatabase = requireEnv("POSTGRES_DATABASE");
-        this.postgresUser = getEnv("POSTGRES_USER", "postgres");
-        this.postgresPassword = requireEnv("POSTGRES_PASSWORD");
-        this.postgresSslMode = getEnv("POSTGRES_SSL_MODE", "prefer");
-
         this.schemaRegistryUrl = getEnv("SCHEMA_REGISTRY_URL", "http://localhost:8081");
-
         this.topicPrefix = requireEnv("TOPIC_PREFIX");
         this.httpPort = Integer.parseInt(getEnv("HTTP_PORT", "8080"));
-    }
-
-    /**
-     * Builds the Debezium {@link Configuration} for the Postgres connector side.
-     */
-    public Configuration toDebeziumConfig() {
-        Properties props = new Properties();
-        props.put("database.hostname", postgresHost);
-        props.put("database.port", String.valueOf(postgresPort));
-        props.put("database.dbname", postgresDatabase);
-        props.put("database.user", postgresUser);
-        props.put("database.password", postgresPassword);
-        props.put("database.sslmode", postgresSslMode);
-        props.put("topic.prefix", topicPrefix);
-        // Required for Avro-compatible schema names
-        props.put("schema.name.adjustment.mode", "avro");
-        // Required by config validation, never used at runtime
-        props.put("plugin.name", "pgoutput");
-        props.put("slot.name", "dummy_slot");
-        return Configuration.from(props);
-    }
-
-    /**
-     * Builds the Schema Registry client configuration map.
-     */
-    public Map<String, String> toSchemaRegistryConfig() {
-        Map<String, String> srProps = new HashMap<>();
-        srProps.put("schema.registry.url", schemaRegistryUrl);
-        return srProps;
     }
 
     public String getSchemaRegistryUrl() {

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/SchemaRegistrationRequest.java
@@ -12,6 +12,9 @@ public class SchemaRegistrationRequest {
     @JsonProperty("tables")
     private List<String> tables;
 
+    @JsonProperty("connection_string")
+    private String connectionString;
+
     public SchemaRegistrationRequest() {
     }
 
@@ -21,5 +24,13 @@ public class SchemaRegistrationRequest {
 
     public void setTables(List<String> tables) {
         this.tables = tables;
+    }
+
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
     }
 }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
@@ -15,14 +15,17 @@ import io.debezium.relational.Tables;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import org.apache.kafka.connect.data.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -30,83 +33,60 @@ import java.util.Set;
  * Mirrors the initialization from {@code PostgresConnectorTask.start()} but strips out
  * everything CDC-related — no replication slots, no streaming, no snapshotter.
  * <p>
- * The Postgres connection is initialized lazily on the first call to {@link #readSchemas},
- * so the service can start without Postgres being available. The connection is then
- * reused for subsequent calls.
+ * The Postgres connection is opened on every {@link #readSchemas} call and closed
+ * before returning, so each request can target a different database.
  */
-public class DebeziumSchemaReader implements AutoCloseable {
+public class DebeziumSchemaReader {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumSchemaReader.class);
+    private static final String DEFAULT_SSL_MODE = "prefer";
+    private static final int DEFAULT_PG_PORT = 5432;
 
-    private final PostgresConnectorConfig connectorConfig;
+    private final String topicPrefix;
     private final TopicNamingStrategy<TableId> topicNamingStrategy;
 
-    // Lazily initialized on first readSchemas() call, then reused
-    private volatile PostgresConnection pgConnection;
-    private volatile TableSchemaBuilder tableSchemaBuilder;
-
     @SuppressWarnings("unchecked")
-    public DebeziumSchemaReader(Configuration config) {
-        this.connectorConfig = new PostgresConnectorConfig(config);
-        this.topicNamingStrategy = connectorConfig.getTopicNamingStrategy(
-                PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
+    public DebeziumSchemaReader(String topicPrefix) {
+        this.topicPrefix = topicPrefix;
+        // The topic naming strategy depends only on the topic prefix, so it can be built once
+        // from a config that has no Postgres connection details.
+        PostgresConnectorConfig baseConfig = new PostgresConnectorConfig(buildBaseConfig(topicPrefix));
+        this.topicNamingStrategy = baseConfig.getTopicNamingStrategy(PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
     }
 
     /**
-     * Reads the Kafka Connect schemas for the specified tables.
+     * Reads the Kafka Connect schemas for the specified tables, opening a fresh Postgres
+     * connection for the duration of the call.
      *
-     * @param tableNames list of table names in "schema.table" or "table" format
+     * @param connectionString a {@code postgresql://user:password@host:port/dbname[?sslmode=...]} URL
+     * @param tableNames       list of table names in "schema.table" or "table" format
      * @return ordered map from TableId to TableSchema
      * @throws RuntimeException if a table is not found or a database error occurs
      */
-    public Map<TableId, TableSchema> readSchemas(List<String> tableNames) throws SQLException {
-        ensureConnected();
+    public Map<TableId, TableSchema> readSchemas(String connectionString, List<String> tableNames) throws SQLException {
+        // PostgresConnectorConfig construction reflectively loads classes (e.g. PostgresSourceInfoStructMaker)
+        // via the thread's context classloader. HTTP server worker threads inherit a classloader that doesn't
+        // see those classes, so we pin the loader to this class's for the duration of the call.
+        Thread current = Thread.currentThread();
+        ClassLoader previousLoader = current.getContextClassLoader();
+        current.setContextClassLoader(DebeziumSchemaReader.class.getClassLoader());
+        try {
+            return doReadSchemas(connectionString, tableNames);
+        }
+        finally {
+            current.setContextClassLoader(previousLoader);
+        }
+    }
 
-        // Parse table names, defaulting schema to "public" when not specified
-        // (mirrors PostgresSchema.parse() which is protected)
+    private Map<TableId, TableSchema> doReadSchemas(String connectionString, List<String> tableNames) throws SQLException {
+        Configuration config = buildConfig(connectionString, topicPrefix);
+        PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
+
         List<TableId> requestedIds = tableNames.stream()
                 .map(DebeziumSchemaReader::parseTableId)
                 .toList();
-
         Set<TableId> requestedSet = Set.copyOf(requestedIds);
         Tables.TableFilter filter = Tables.TableFilter.fromPredicate(requestedSet::contains);
 
-        // Read schema metadata from JDBC
-        Tables tables = new Tables();
-        pgConnection.readSchema(tables, null, null, filter, null, true);
-
-        Map<TableId, TableSchema> result = new LinkedHashMap<>();
-        for (TableId tableId : requestedIds) {
-            Table table = tables.forTable(tableId);
-            if (table == null) {
-                throw new RuntimeException("Table not found: " + tableId);
-            }
-            TableSchema tableSchema = tableSchemaBuilder.create(
-                    topicNamingStrategy, table, null, null, null);
-            result.put(tableId, tableSchema);
-        }
-        return result;
-    }
-
-    /**
-     * Initializes the Postgres connection and related components on the first call.
-     * Subsequent calls are no-ops if the connection is already established.
-     * Uses double-checked locking to avoid redundant initialization under concurrency.
-     */
-    private void ensureConnected() {
-        if (pgConnection != null) {
-            return;
-        }
-        synchronized (this) {
-            if (pgConnection != null) {
-                return;
-            }
-            LOGGER.info("Initializing Postgres connection");
-            initConnection();
-        }
-    }
-
-    private void initConnection() {
         final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
 
         final Charset databaseCharset;
@@ -118,21 +98,119 @@ public class DebeziumSchemaReader implements AutoCloseable {
         final PostgresValueConverterBuilder vcBuilder = (typeRegistry) -> PostgresValueConverter.of(
                 connectorConfig, databaseCharset, typeRegistry);
 
-        final PostgresConnection connection = new PostgresConnection(
-                connectorConfig.getJdbcConfig(), vcBuilder, PostgresConnection.CONNECTION_GENERAL);
+        try (PostgresConnection connection = new PostgresConnection(
+                connectorConfig.getJdbcConfig(), vcBuilder, PostgresConnection.CONNECTION_GENERAL)) {
 
-        final PostgresDefaultValueConverter defaultValueConverter = connection.getDefaultValueConverter();
-        final PostgresValueConverter valueConverter = vcBuilder.build(connection.getTypeRegistry());
+            final PostgresDefaultValueConverter defaultValueConverter = connection.getDefaultValueConverter();
+            final PostgresValueConverter valueConverter = vcBuilder.build(connection.getTypeRegistry());
+            final Schema sourceInfoSchema = connectorConfig.getSourceInfoStructMaker().schema();
+            final CustomConverterRegistry customConverterRegistry = new CustomConverterRegistry(null);
+            TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
+                    valueConverter, defaultValueConverter, schemaNameAdjuster,
+                    customConverterRegistry, sourceInfoSchema,
+                    connectorConfig.getFieldNamer(), false);
 
-        final Schema sourceInfoSchema = connectorConfig.getSourceInfoStructMaker().schema();
-        final CustomConverterRegistry customConverterRegistry = new CustomConverterRegistry(null);
-        this.tableSchemaBuilder = new TableSchemaBuilder(
-                valueConverter, defaultValueConverter, schemaNameAdjuster,
-                customConverterRegistry, sourceInfoSchema,
-                connectorConfig.getFieldNamer(), false);
+            Tables tables = new Tables();
+            connection.readSchema(tables, null, null, filter, null, true);
 
-        this.pgConnection = connection;
-        LOGGER.info("Postgres connection initialized successfully");
+            Map<TableId, TableSchema> result = new LinkedHashMap<>();
+            for (TableId tableId : requestedIds) {
+                Table table = tables.forTable(tableId);
+                if (table == null) {
+                    throw new RuntimeException("Table not found: " + tableId);
+                }
+                TableSchema tableSchema = tableSchemaBuilder.create(
+                        topicNamingStrategy, table, null, null, null);
+                result.put(tableId, tableSchema);
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Parses a Postgres connection URL ({@code postgresql://user:pass@host:port/dbname[?sslmode=...]})
+     * and produces a Debezium {@link Configuration} suitable for instantiating a
+     * {@link PostgresConnectorConfig}.
+     */
+    static Configuration buildConfig(String connectionString, String topicPrefix) {
+        if (connectionString == null || connectionString.isBlank()) {
+            throw new IllegalArgumentException("connection_string must not be empty");
+        }
+        URI uri;
+        try {
+            uri = new URI(connectionString);
+        }
+        catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid connection_string: " + e.getMessage(), e);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equals("postgresql") || scheme.equals("postgres"))) {
+            throw new IllegalArgumentException(
+                    "connection_string must start with 'postgresql://' or 'postgres://'");
+        }
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("connection_string is missing the host");
+        }
+        int port = uri.getPort() == -1 ? DEFAULT_PG_PORT : uri.getPort();
+        String path = uri.getPath();
+        if (path == null || path.length() <= 1) {
+            throw new IllegalArgumentException("connection_string is missing the database name");
+        }
+        String database = path.substring(1);
+
+        String user = "postgres";
+        String password = "";
+        String userInfo = uri.getUserInfo();
+        if (userInfo != null && !userInfo.isEmpty()) {
+            int colon = userInfo.indexOf(':');
+            if (colon >= 0) {
+                user = URLDecoder.decode(userInfo.substring(0, colon), StandardCharsets.UTF_8);
+                password = URLDecoder.decode(userInfo.substring(colon + 1), StandardCharsets.UTF_8);
+            }
+            else {
+                user = URLDecoder.decode(userInfo, StandardCharsets.UTF_8);
+            }
+        }
+
+        String sslMode = DEFAULT_SSL_MODE;
+        String query = uri.getQuery();
+        if (query != null) {
+            for (String param : query.split("&")) {
+                int eq = param.indexOf('=');
+                if (eq > 0) {
+                    String key = param.substring(0, eq);
+                    String value = URLDecoder.decode(param.substring(eq + 1), StandardCharsets.UTF_8);
+                    if ("sslmode".equals(key)) {
+                        sslMode = value;
+                    }
+                }
+            }
+        }
+
+        Properties props = baseProps(topicPrefix);
+        props.put("database.hostname", host);
+        props.put("database.port", String.valueOf(port));
+        props.put("database.dbname", database);
+        props.put("database.user", user);
+        props.put("database.password", password);
+        props.put("database.sslmode", sslMode);
+        return Configuration.from(props);
+    }
+
+    private static Configuration buildBaseConfig(String topicPrefix) {
+        return Configuration.from(baseProps(topicPrefix));
+    }
+
+    private static Properties baseProps(String topicPrefix) {
+        Properties props = new Properties();
+        props.put("topic.prefix", topicPrefix);
+        // Required for Avro-compatible schema names
+        props.put("schema.name.adjustment.mode", "avro");
+        // Required by config validation, never used at runtime
+        props.put("plugin.name", "pgoutput");
+        props.put("slot.name", "dummy_slot");
+        return props;
     }
 
     /**
@@ -154,21 +232,5 @@ public class DebeziumSchemaReader implements AutoCloseable {
      */
     public TopicNamingStrategy<TableId> getTopicNamingStrategy() {
         return topicNamingStrategy;
-    }
-
-    @Override
-    public void close() {
-        synchronized (this) {
-            if (pgConnection != null) {
-                try {
-                    pgConnection.close();
-                }
-                catch (Exception e) {
-                    LOGGER.warn("Error closing PostgresConnection", e);
-                }
-                pgConnection = null;
-                tableSchemaBuilder = null;
-            }
-        }
     }
 }

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
@@ -25,7 +25,6 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -49,7 +48,7 @@ public class DebeziumSchemaReader {
         this.topicPrefix = topicPrefix;
         // The topic naming strategy depends only on the topic prefix, so build it once here
         // from a config that has no Postgres connection details.
-        PostgresConnectorConfig baseConfig = new PostgresConnectorConfig(Configuration.from(baseProps(topicPrefix)));
+        PostgresConnectorConfig baseConfig = new PostgresConnectorConfig(baseConfig(topicPrefix));
         this.topicNamingStrategy = baseConfig.getTopicNamingStrategy(PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
     }
 
@@ -188,25 +187,25 @@ public class DebeziumSchemaReader {
             }
         }
 
-        Properties props = baseProps(topicPrefix);
-        props.put("database.hostname", host);
-        props.put("database.port", String.valueOf(port));
-        props.put("database.dbname", database);
-        props.put("database.user", user);
-        props.put("database.password", password);
-        props.put("database.sslmode", sslMode);
-        return Configuration.from(props);
+        return baseConfig(topicPrefix).edit()
+                .with("database.hostname", host)
+                .with("database.port", port)
+                .with("database.dbname", database)
+                .with("database.user", user)
+                .with("database.password", password)
+                .with("database.sslmode", sslMode)
+                .build();
     }
 
-    private static Properties baseProps(String topicPrefix) {
-        Properties props = new Properties();
-        props.put("topic.prefix", topicPrefix);
-        // Required for Avro-compatible schema names
-        props.put("schema.name.adjustment.mode", "avro");
-        // Required by config validation, never used at runtime
-        props.put("plugin.name", "pgoutput");
-        props.put("slot.name", "dummy_slot");
-        return props;
+    private static Configuration baseConfig(String topicPrefix) {
+        return Configuration.create()
+                .with("topic.prefix", topicPrefix)
+                // Required for Avro-compatible schema names
+                .with("schema.name.adjustment.mode", "avro")
+                // Required by config validation, never used at runtime
+                .with("plugin.name", "pgoutput")
+                .with("slot.name", "dummy_slot")
+                .build();
     }
 
     /**

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
@@ -6,6 +6,7 @@ import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.PostgresConnection.PostgresValueConverterBuilder;
 import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;
+import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -32,24 +33,26 @@ import java.util.Set;
  * Mirrors the initialization from {@code PostgresConnectorTask.start()} but strips out
  * everything CDC-related — no replication slots, no streaming, no snapshotter.
  * <p>
- * The Postgres connection is opened on every {@link #readSchemas} call and closed
- * before returning, so each request can target a different database.
+ * The connector-level configuration is built once at construction; the JDBC connection
+ * is parsed from a {@code postgresql://...} URL and opened fresh on every
+ * {@link #readSchemas} call, so each request can target a different database.
  */
 public class DebeziumSchemaReader {
 
     private static final String DEFAULT_SSL_MODE = "prefer";
     private static final int DEFAULT_PG_PORT = 5432;
 
-    private final String topicPrefix;
+    private final PostgresConnectorConfig connectorConfig;
     private final TopicNamingStrategy<TableId> topicNamingStrategy;
+    private final SchemaNameAdjuster schemaNameAdjuster;
+    private final Schema sourceInfoSchema;
 
     @SuppressWarnings("unchecked")
     public DebeziumSchemaReader(String topicPrefix) {
-        this.topicPrefix = topicPrefix;
-        // The topic naming strategy depends only on the topic prefix, so build it once here
-        // from a config that has no Postgres connection details.
-        PostgresConnectorConfig baseConfig = new PostgresConnectorConfig(baseConfig(topicPrefix));
-        this.topicNamingStrategy = baseConfig.getTopicNamingStrategy(PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
+        this.connectorConfig = new PostgresConnectorConfig(staticConfig(topicPrefix));
+        this.topicNamingStrategy = connectorConfig.getTopicNamingStrategy(PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
+        this.schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
+        this.sourceInfoSchema = connectorConfig.getSourceInfoStructMaker().schema();
     }
 
     /**
@@ -62,23 +65,7 @@ public class DebeziumSchemaReader {
      * @throws RuntimeException if a table is not found or a database error occurs
      */
     public Map<TableId, TableSchema> readSchemas(String connectionString, List<String> tableNames) throws SQLException {
-        // PostgresConnectorConfig construction reflectively loads classes (e.g. PostgresSourceInfoStructMaker)
-        // via the thread's context classloader. HTTP server worker threads inherit a classloader that doesn't
-        // see those classes, so we pin the loader to this class's for the duration of the call.
-        Thread current = Thread.currentThread();
-        ClassLoader previousLoader = current.getContextClassLoader();
-        current.setContextClassLoader(DebeziumSchemaReader.class.getClassLoader());
-        try {
-            return doReadSchemas(connectionString, tableNames);
-        }
-        finally {
-            current.setContextClassLoader(previousLoader);
-        }
-    }
-
-    private Map<TableId, TableSchema> doReadSchemas(String connectionString, List<String> tableNames) throws SQLException {
-        Configuration config = buildConfig(connectionString, topicPrefix);
-        PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
+        JdbcConfiguration jdbcConfig = parseJdbcConfig(connectionString);
 
         List<TableId> requestedIds = tableNames.stream()
                 .map(DebeziumSchemaReader::parseTableId)
@@ -86,27 +73,20 @@ public class DebeziumSchemaReader {
         Set<TableId> requestedSet = Set.copyOf(requestedIds);
         Tables.TableFilter filter = Tables.TableFilter.fromPredicate(requestedSet::contains);
 
-        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
-
-        final Charset databaseCharset;
-        try (PostgresConnection temp = new PostgresConnection(
-                connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
+        Charset databaseCharset;
+        try (PostgresConnection temp = new PostgresConnection(jdbcConfig, PostgresConnection.CONNECTION_GENERAL)) {
             databaseCharset = temp.getDatabaseCharset();
         }
 
-        final PostgresValueConverterBuilder vcBuilder = (typeRegistry) -> PostgresValueConverter.of(
+        PostgresValueConverterBuilder vcBuilder = (typeRegistry) -> PostgresValueConverter.of(
                 connectorConfig, databaseCharset, typeRegistry);
 
-        try (PostgresConnection connection = new PostgresConnection(
-                connectorConfig.getJdbcConfig(), vcBuilder, PostgresConnection.CONNECTION_GENERAL)) {
-
-            final PostgresDefaultValueConverter defaultValueConverter = connection.getDefaultValueConverter();
-            final PostgresValueConverter valueConverter = vcBuilder.build(connection.getTypeRegistry());
-            final Schema sourceInfoSchema = connectorConfig.getSourceInfoStructMaker().schema();
-            final CustomConverterRegistry customConverterRegistry = new CustomConverterRegistry(null);
+        try (PostgresConnection connection = new PostgresConnection(jdbcConfig, vcBuilder, PostgresConnection.CONNECTION_GENERAL)) {
+            PostgresDefaultValueConverter defaultValueConverter = connection.getDefaultValueConverter();
+            PostgresValueConverter valueConverter = vcBuilder.build(connection.getTypeRegistry());
             TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
                     valueConverter, defaultValueConverter, schemaNameAdjuster,
-                    customConverterRegistry, sourceInfoSchema,
+                    new CustomConverterRegistry(null), sourceInfoSchema,
                     connectorConfig.getFieldNamer(), false);
 
             Tables tables = new Tables();
@@ -128,10 +108,9 @@ public class DebeziumSchemaReader {
 
     /**
      * Parses a Postgres connection URL ({@code postgresql://user:pass@host:port/dbname[?sslmode=...]})
-     * and produces a Debezium {@link Configuration} suitable for instantiating a
-     * {@link PostgresConnectorConfig}.
+     * into a {@link JdbcConfiguration} suitable for opening a {@link PostgresConnection}.
      */
-    static Configuration buildConfig(String connectionString, String topicPrefix) {
+    static JdbcConfiguration parseJdbcConfig(String connectionString) {
         if (connectionString == null || connectionString.isBlank()) {
             throw new IllegalArgumentException("connection_string must not be empty");
         }
@@ -187,17 +166,21 @@ public class DebeziumSchemaReader {
             }
         }
 
-        return baseConfig(topicPrefix).edit()
-                .with("database.hostname", host)
-                .with("database.port", port)
-                .with("database.dbname", database)
-                .with("database.user", user)
-                .with("database.password", password)
-                .with("database.sslmode", sslMode)
+        return JdbcConfiguration.create()
+                .withHostname(host)
+                .withPort(port)
+                .withDatabase(database)
+                .withUser(user)
+                .withPassword(password)
+                .with("sslmode", sslMode)
                 .build();
     }
 
-    private static Configuration baseConfig(String topicPrefix) {
+    /**
+     * Builds the static, connector-level configuration. Connection details are not part of
+     * this config — they come per-request via {@link #parseJdbcConfig(String)}.
+     */
+    private static Configuration staticConfig(String topicPrefix) {
         return Configuration.create()
                 .with("topic.prefix", topicPrefix)
                 // Required for Avro-compatible schema names

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/DebeziumSchemaReader.java
@@ -47,9 +47,9 @@ public class DebeziumSchemaReader {
     @SuppressWarnings("unchecked")
     public DebeziumSchemaReader(String topicPrefix) {
         this.topicPrefix = topicPrefix;
-        // The topic naming strategy depends only on the topic prefix, so it can be built once
+        // The topic naming strategy depends only on the topic prefix, so build it once here
         // from a config that has no Postgres connection details.
-        PostgresConnectorConfig baseConfig = new PostgresConnectorConfig(buildBaseConfig(topicPrefix));
+        PostgresConnectorConfig baseConfig = new PostgresConnectorConfig(Configuration.from(baseProps(topicPrefix)));
         this.topicNamingStrategy = baseConfig.getTopicNamingStrategy(PostgresConnectorConfig.TOPIC_NAMING_STRATEGY);
     }
 
@@ -198,10 +198,6 @@ public class DebeziumSchemaReader {
         return Configuration.from(props);
     }
 
-    private static Configuration buildBaseConfig(String topicPrefix) {
-        return Configuration.from(baseProps(topicPrefix));
-    }
-
     private static Properties baseProps(String topicPrefix) {
         Properties props = new Properties();
         props.put("topic.prefix", topicPrefix);
@@ -227,9 +223,6 @@ public class DebeziumSchemaReader {
                 : tableId;
     }
 
-    /**
-     * Returns the topic naming strategy, used to derive subjects for SR registration.
-     */
     public TopicNamingStrategy<TableId> getTopicNamingStrategy() {
         return topicNamingStrategy;
     }

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerIT.java
@@ -1,7 +1,6 @@
 package io.debezium.schematranslator.api;
 
 import com.sun.net.httpserver.HttpServer;
-import io.debezium.config.Configuration;
 import io.debezium.schematranslator.schema.AvroSchemaConverter;
 import io.debezium.schematranslator.schema.DebeziumSchemaReader;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
@@ -29,7 +28,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,11 +70,10 @@ class RegisterSchemasHandlerIT {
 
     private HttpServer handlerServer;
     private int handlerPort;
-    private DebeziumSchemaReader reader;
 
     @BeforeEach
     void setUp() throws Exception {
-        reader = new DebeziumSchemaReader(buildConfig());
+        DebeziumSchemaReader reader = new DebeziumSchemaReader("test");
         String srUrl = "http://localhost:" + schemaRegistry.getMappedPort(8081);
         SchemaRegistryPublisher publisher = new SchemaRegistryPublisher(srUrl);
 
@@ -104,9 +101,8 @@ class RegisterSchemasHandlerIT {
     }
 
     @AfterEach
-    void tearDown() throws Exception {
+    void tearDown() {
         handlerServer.stop(0);
-        reader.close();
     }
 
     @Test
@@ -117,7 +113,7 @@ class RegisterSchemasHandlerIT {
                 "  price NUMERIC" +
                 ")");
 
-        HttpURLConnection conn = post("{\"tables\":[\"public.products\"]}");
+        HttpURLConnection conn = post(registerBody("public.products"));
         String body = new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
         assertThat(conn.getResponseCode()).isEqualTo(200);
@@ -142,13 +138,13 @@ class RegisterSchemasHandlerIT {
                 "  name TEXT NOT NULL" +
                 ")");
 
-        HttpURLConnection conn1 = post("{\"tables\":[\"public.evolution_ok\"]}");
+        HttpURLConnection conn1 = post(registerBody("public.evolution_ok"));
         assertThat(conn1.getResponseCode()).isEqualTo(200);
         conn1.getInputStream().readAllBytes(); // drain
 
         execute("ALTER TABLE public.evolution_ok ADD COLUMN notes TEXT");
 
-        HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_ok\"]}");
+        HttpURLConnection conn2 = post(registerBody("public.evolution_ok"));
         String body = new String(conn2.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
         assertThat(conn2.getResponseCode()).isEqualTo(200);
@@ -168,13 +164,13 @@ class RegisterSchemasHandlerIT {
                 "  name TEXT NOT NULL" +
                 ")");
 
-        HttpURLConnection conn1 = post("{\"tables\":[\"public.evolution_bad\"]}");
+        HttpURLConnection conn1 = post(registerBody("public.evolution_bad"));
         assertThat(conn1.getResponseCode()).isEqualTo(200);
         conn1.getInputStream().readAllBytes(); // drain
 
         execute("ALTER TABLE public.evolution_bad ADD COLUMN required_flag TEXT NOT NULL");
 
-        HttpURLConnection conn2 = post("{\"tables\":[\"public.evolution_bad\"]}");
+        HttpURLConnection conn2 = post(registerBody("public.evolution_bad"));
         assertThat(conn2.getResponseCode()).isEqualTo(409);
         InputStream errStream = conn2.getErrorStream();
         String errorBody = errStream != null ? new String(errStream.readAllBytes(), StandardCharsets.UTF_8) : "";
@@ -197,7 +193,7 @@ class RegisterSchemasHandlerIT {
                 "  label TEXT NOT NULL" +
                 ")");
 
-        HttpURLConnection postConn = post("{\"tables\":[\"public.delete_test\"]}");
+        HttpURLConnection postConn = post(registerBody("public.delete_test"));
         assertThat(postConn.getResponseCode()).isEqualTo(200);
         postConn.getInputStream().readAllBytes(); // drain
 
@@ -228,19 +224,24 @@ class RegisterSchemasHandlerIT {
         assertThat(emptyJson.get("deleted_count").asInt()).isEqualTo(0);
     }
 
-    private static Configuration buildConfig() {
-        Properties props = new Properties();
-        props.put("database.hostname", postgres.getHost());
-        props.put("database.port", String.valueOf(postgres.getMappedPort(5432)));
-        props.put("database.dbname", postgres.getDatabaseName());
-        props.put("database.user", postgres.getUsername());
-        props.put("database.password", postgres.getPassword());
-        props.put("database.sslmode", "disable");
-        props.put("topic.prefix", "test");
-        props.put("schema.name.adjustment.mode", "avro");
-        props.put("plugin.name", "pgoutput");
-        props.put("slot.name", "dummy_slot");
-        return Configuration.from(props);
+    @Test
+    void missingConnectionStringReturns400() throws Exception {
+        HttpURLConnection conn = post("{\"tables\":[\"public.products\"]}");
+        assertThat(conn.getResponseCode()).isEqualTo(400);
+        InputStream errStream = conn.getErrorStream();
+        String errorBody = errStream != null ? new String(errStream.readAllBytes(), StandardCharsets.UTF_8) : "";
+        assertThat(errorBody).contains("connection_string");
+    }
+
+    private static String connectionString() {
+        return String.format("postgresql://%s:%s@%s:%d/%s?sslmode=disable",
+                postgres.getUsername(), postgres.getPassword(),
+                postgres.getHost(), postgres.getMappedPort(5432),
+                postgres.getDatabaseName());
+    }
+
+    private static String registerBody(String table) {
+        return "{\"tables\":[\"" + table + "\"],\"connection_string\":\"" + connectionString() + "\"}";
     }
 
     private HttpURLConnection post(String jsonBody) throws Exception {

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -35,6 +35,9 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class RegisterSchemasHandlerTest {
 
+    private static final String CONN = "postgresql://postgres:postgres@localhost:5432/testdb";
+    private static final String REQUEST_BODY = "{\"tables\":[\"public.users\"],\"connection_string\":\"" + CONN + "\"}";
+
     @Mock
     private DebeziumSchemaReader schemaReader;
     @Mock
@@ -71,7 +74,7 @@ class RegisterSchemasHandlerTest {
 
     @Test
     void missingTablesFieldReturns400() throws Exception {
-        HttpExchange exchange = mockExchange("POST", "{}");
+        HttpExchange exchange = mockExchange("POST", "{\"connection_string\":\"" + CONN + "\"}");
 
         handler.handle(exchange);
 
@@ -82,7 +85,7 @@ class RegisterSchemasHandlerTest {
 
     @Test
     void emptyTablesListReturns400() throws Exception {
-        HttpExchange exchange = mockExchange("POST", "{\"tables\":[]}");
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[],\"connection_string\":\"" + CONN + "\"}");
 
         handler.handle(exchange);
 
@@ -90,9 +93,44 @@ class RegisterSchemasHandlerTest {
     }
 
     @Test
-    void postgresErrorReturns500() throws Exception {
+    void missingConnectionStringReturns400() throws Exception {
         HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
-        when(schemaReader.readSchemas(anyList())).thenThrow(new RuntimeException("Connection refused"));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(400), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText()).contains("connection_string");
+    }
+
+    @Test
+    void blankConnectionStringReturns400() throws Exception {
+        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"],\"connection_string\":\"   \"}");
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(400), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText()).contains("connection_string");
+    }
+
+    @Test
+    void invalidConnectionStringReturns400() throws Exception {
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
+        when(schemaReader.readSchemas(anyString(), anyList()))
+                .thenThrow(new IllegalArgumentException("connection_string is missing the host"));
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(400), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("message").asText()).contains("missing the host");
+    }
+
+    @Test
+    void postgresErrorReturns500() throws Exception {
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
+        when(schemaReader.readSchemas(anyString(), anyList())).thenThrow(new RuntimeException("Connection refused"));
 
         handler.handle(exchange);
 
@@ -103,7 +141,7 @@ class RegisterSchemasHandlerTest {
 
     @Test
     void schemaIncompatibilityReturns409() throws Exception {
-        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
         setupSchemaReaderAndConverter();
         doThrow(new SchemaIncompatibilityException("incompatible schema", new Exception(),
                 "{\"old\":true}", "{\"new\":true}"))
@@ -124,7 +162,9 @@ class RegisterSchemasHandlerTest {
 
     @Test
     void multipleSchemaIncompatibilitiesReturnsAllErrors() throws Exception {
-        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\",\"public.orders\"]}");
+        HttpExchange exchange = mockExchange(
+                "POST",
+                "{\"tables\":[\"public.users\",\"public.orders\"],\"connection_string\":\"" + CONN + "\"}");
         setupSchemaReaderAndConverterForTables();
         doThrow(new SchemaIncompatibilityException("incompatible schema for users", new Exception(),
                 "{\"old\":\"users\"}", "{\"new\":\"users\"}"))
@@ -149,7 +189,7 @@ class RegisterSchemasHandlerTest {
 
     @Test
     void schemaRegistryIoErrorReturns500() throws Exception {
-        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
         setupSchemaReaderAndConverter();
         doThrow(new IOException("network error"))
                 .when(publisher).register(any(), any(), any());
@@ -163,7 +203,7 @@ class RegisterSchemasHandlerTest {
 
     @Test
     void successfulRegistrationReturns200WithResults() throws Exception {
-        HttpExchange exchange = mockExchange("POST", "{\"tables\":[\"public.users\"]}");
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
         setupSchemaReaderAndConverter();
         when(publisher.register(eq("public.users"), eq("test.public.users-value"), any()))
                 .thenReturn(new RegisteredSchema("public.users", "test.public.users-value", 1, 1));
@@ -173,6 +213,7 @@ class RegisterSchemasHandlerTest {
         handler.handle(exchange);
 
         verify(exchange).sendResponseHeaders(eq(200), anyLong());
+        verify(schemaReader).readSchemas(eq(CONN), eq(List.of("public.users")));
         JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
         assertThat(response.get("registered_schemas")).hasSize(2);
         JsonNode value = response.get("registered_schemas").get(0);
@@ -203,7 +244,7 @@ class RegisterSchemasHandlerTest {
         Map<TableId, TableSchema> schemas = new LinkedHashMap<>();
         schemas.put(usersId, usersSchema);
         schemas.put(ordersId, ordersSchema);
-        when(schemaReader.readSchemas(List.of("public.users", "public.orders"))).thenReturn(schemas);
+        when(schemaReader.readSchemas(eq(CONN), eq(List.of("public.users", "public.orders")))).thenReturn(schemas);
 
         TopicNamingStrategy<TableId> strategy = mock(TopicNamingStrategy.class);
         when(strategy.dataChangeTopic(usersId)).thenReturn("test.public.users");
@@ -226,7 +267,7 @@ class RegisterSchemasHandlerTest {
 
         Map<TableId, TableSchema> schemas = new LinkedHashMap<>();
         schemas.put(tableId, tableSchema);
-        when(schemaReader.readSchemas(List.of("public.users"))).thenReturn(schemas);
+        when(schemaReader.readSchemas(eq(CONN), eq(List.of("public.users")))).thenReturn(schemas);
 
         TopicNamingStrategy<TableId> strategy = mock(TopicNamingStrategy.class);
         when(strategy.dataChangeTopic(tableId)).thenReturn("test.public.users");

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderIT.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderIT.java
@@ -1,9 +1,7 @@
 package io.debezium.schematranslator.schema;
 
-import io.debezium.config.Configuration;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -14,7 +12,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.Map;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,12 +29,7 @@ class DebeziumSchemaReaderIT {
 
     @BeforeEach
     void setUp() {
-        reader = new DebeziumSchemaReader(buildConfig());
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        reader.close();
+        reader = new DebeziumSchemaReader("test");
     }
 
     @Test
@@ -48,7 +40,7 @@ class DebeziumSchemaReaderIT {
                 "  email VARCHAR(255)" +
                 ")");
 
-        Map<TableId, TableSchema> schemas = reader.readSchemas(java.util.List.of("public.users"));
+        Map<TableId, TableSchema> schemas = reader.readSchemas(connectionString(), java.util.List.of("public.users"));
 
         assertThat(schemas).hasSize(1);
         TableSchema tableSchema = schemas.values().iterator().next();
@@ -59,7 +51,7 @@ class DebeziumSchemaReaderIT {
 
     @Test
     void throwsForUnknownTable() {
-        assertThatThrownBy(() -> reader.readSchemas(java.util.List.of("public.nonexistent")))
+        assertThatThrownBy(() -> reader.readSchemas(connectionString(), java.util.List.of("public.nonexistent")))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Table not found: public.nonexistent");
     }
@@ -71,7 +63,7 @@ class DebeziumSchemaReaderIT {
                 "  amount NUMERIC NOT NULL" +
                 ")");
 
-        Map<TableId, TableSchema> schemas = reader.readSchemas(java.util.List.of("orders"));
+        Map<TableId, TableSchema> schemas = reader.readSchemas(connectionString(), java.util.List.of("orders"));
 
         assertThat(schemas).hasSize(1);
         TableId tableId = schemas.keySet().iterator().next();
@@ -79,19 +71,11 @@ class DebeziumSchemaReaderIT {
         assertThat(tableId.table()).isEqualTo("orders");
     }
 
-    private Configuration buildConfig() {
-        Properties props = new Properties();
-        props.put("database.hostname", postgres.getHost());
-        props.put("database.port", String.valueOf(postgres.getMappedPort(5432)));
-        props.put("database.dbname", postgres.getDatabaseName());
-        props.put("database.user", postgres.getUsername());
-        props.put("database.password", postgres.getPassword());
-        props.put("database.sslmode", "disable");
-        props.put("topic.prefix", "test");
-        props.put("schema.name.adjustment.mode", "avro");
-        props.put("plugin.name", "pgoutput");
-        props.put("slot.name", "dummy_slot");
-        return Configuration.from(props);
+    private static String connectionString() {
+        return String.format("postgresql://%s:%s@%s:%d/%s?sslmode=disable",
+                postgres.getUsername(), postgres.getPassword(),
+                postgres.getHost(), postgres.getMappedPort(5432),
+                postgres.getDatabaseName());
     }
 
     private void execute(String sql) throws Exception {

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderTest.java
@@ -1,6 +1,6 @@
 package io.debezium.schematranslator.schema;
 
-import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,101 +9,95 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class DebeziumSchemaReaderTest {
 
     @Test
-    void buildConfigParsesFullUrl() {
-        Configuration config = DebeziumSchemaReader.buildConfig(
-                "postgresql://alice:secret@pg.example.com:6543/llm_obs?sslmode=require",
-                "topicPrefix");
+    void parseJdbcConfigParsesFullUrl() {
+        JdbcConfiguration jdbc = DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql://alice:secret@pg.example.com:6543/llm_obs?sslmode=require");
 
-        assertThat(config.getString("database.hostname")).isEqualTo("pg.example.com");
-        assertThat(config.getString("database.port")).isEqualTo("6543");
-        assertThat(config.getString("database.dbname")).isEqualTo("llm_obs");
-        assertThat(config.getString("database.user")).isEqualTo("alice");
-        assertThat(config.getString("database.password")).isEqualTo("secret");
-        assertThat(config.getString("database.sslmode")).isEqualTo("require");
-        assertThat(config.getString("topic.prefix")).isEqualTo("topicPrefix");
+        assertThat(jdbc.getHostname()).isEqualTo("pg.example.com");
+        assertThat(jdbc.getPort()).isEqualTo(6543);
+        assertThat(jdbc.getDatabase()).isEqualTo("llm_obs");
+        assertThat(jdbc.getUser()).isEqualTo("alice");
+        assertThat(jdbc.getPassword()).isEqualTo("secret");
+        assertThat(jdbc.getString("sslmode")).isEqualTo("require");
     }
 
     @Test
-    void buildConfigDefaultsPortAndSslMode() {
-        Configuration config = DebeziumSchemaReader.buildConfig(
-                "postgresql://alice:secret@pg.example.com/llm_obs",
-                "topicPrefix");
+    void parseJdbcConfigDefaultsPortAndSslMode() {
+        JdbcConfiguration jdbc = DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql://alice:secret@pg.example.com/llm_obs");
 
-        assertThat(config.getString("database.port")).isEqualTo("5432");
-        assertThat(config.getString("database.sslmode")).isEqualTo("prefer");
+        assertThat(jdbc.getPort()).isEqualTo(5432);
+        assertThat(jdbc.getString("sslmode")).isEqualTo("prefer");
     }
 
     @Test
-    void buildConfigAcceptsPostgresScheme() {
-        Configuration config = DebeziumSchemaReader.buildConfig(
-                "postgres://alice:secret@pg.example.com/llm_obs",
-                "topicPrefix");
+    void parseJdbcConfigAcceptsPostgresScheme() {
+        JdbcConfiguration jdbc = DebeziumSchemaReader.parseJdbcConfig(
+                "postgres://alice:secret@pg.example.com/llm_obs");
 
-        assertThat(config.getString("database.hostname")).isEqualTo("pg.example.com");
+        assertThat(jdbc.getHostname()).isEqualTo("pg.example.com");
     }
 
     @Test
-    void buildConfigDecodesPercentEncodedCredentials() {
-        Configuration config = DebeziumSchemaReader.buildConfig(
-                "postgresql://us%40r:p%40ss@pg.example.com/llm_obs",
-                "topicPrefix");
+    void parseJdbcConfigDecodesPercentEncodedCredentials() {
+        JdbcConfiguration jdbc = DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql://us%40r:p%40ss@pg.example.com/llm_obs");
 
-        assertThat(config.getString("database.user")).isEqualTo("us@r");
-        assertThat(config.getString("database.password")).isEqualTo("p@ss");
+        assertThat(jdbc.getUser()).isEqualTo("us@r");
+        assertThat(jdbc.getPassword()).isEqualTo("p@ss");
     }
 
     @Test
-    void buildConfigHandlesUsernameOnly() {
-        Configuration config = DebeziumSchemaReader.buildConfig(
-                "postgresql://alice@pg.example.com/llm_obs",
-                "topicPrefix");
+    void parseJdbcConfigHandlesUsernameOnly() {
+        JdbcConfiguration jdbc = DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql://alice@pg.example.com/llm_obs");
 
-        assertThat(config.getString("database.user")).isEqualTo("alice");
-        assertThat(config.getString("database.password")).isEqualTo("");
+        assertThat(jdbc.getUser()).isEqualTo("alice");
+        assertThat(jdbc.getPassword()).isEqualTo("");
     }
 
     @Test
-    void buildConfigRejectsNullOrBlank() {
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(null, "topicPrefix"))
+    void parseJdbcConfigRejectsNullOrBlank() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("must not be empty");
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig("   ", "topicPrefix"))
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig("   "))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("must not be empty");
     }
 
     @Test
-    void buildConfigRejectsWrongScheme() {
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
-                "mysql://alice:secret@pg.example.com/llm_obs", "topicPrefix"))
+    void parseJdbcConfigRejectsWrongScheme() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig(
+                "mysql://alice:secret@pg.example.com/llm_obs"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("postgresql://");
     }
 
     @Test
-    void buildConfigRejectsMissingHost() {
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
-                "postgresql:///llm_obs", "topicPrefix"))
+    void parseJdbcConfigRejectsMissingHost() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql:///llm_obs"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("missing the host");
     }
 
     @Test
-    void buildConfigRejectsMissingDatabase() {
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
-                "postgresql://alice:secret@pg.example.com", "topicPrefix"))
+    void parseJdbcConfigRejectsMissingDatabase() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql://alice:secret@pg.example.com"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("missing the database");
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
-                "postgresql://alice:secret@pg.example.com/", "topicPrefix"))
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig(
+                "postgresql://alice:secret@pg.example.com/"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("missing the database");
     }
 
     @Test
-    void buildConfigRejectsMalformedUrl() {
-        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
-                "not a valid uri", "topicPrefix"))
+    void parseJdbcConfigRejectsMalformedUrl() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.parseJdbcConfig(
+                "not a valid uri"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Invalid connection_string");
     }

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/DebeziumSchemaReaderTest.java
@@ -1,0 +1,110 @@
+package io.debezium.schematranslator.schema;
+
+import io.debezium.config.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DebeziumSchemaReaderTest {
+
+    @Test
+    void buildConfigParsesFullUrl() {
+        Configuration config = DebeziumSchemaReader.buildConfig(
+                "postgresql://alice:secret@pg.example.com:6543/llm_obs?sslmode=require",
+                "topicPrefix");
+
+        assertThat(config.getString("database.hostname")).isEqualTo("pg.example.com");
+        assertThat(config.getString("database.port")).isEqualTo("6543");
+        assertThat(config.getString("database.dbname")).isEqualTo("llm_obs");
+        assertThat(config.getString("database.user")).isEqualTo("alice");
+        assertThat(config.getString("database.password")).isEqualTo("secret");
+        assertThat(config.getString("database.sslmode")).isEqualTo("require");
+        assertThat(config.getString("topic.prefix")).isEqualTo("topicPrefix");
+    }
+
+    @Test
+    void buildConfigDefaultsPortAndSslMode() {
+        Configuration config = DebeziumSchemaReader.buildConfig(
+                "postgresql://alice:secret@pg.example.com/llm_obs",
+                "topicPrefix");
+
+        assertThat(config.getString("database.port")).isEqualTo("5432");
+        assertThat(config.getString("database.sslmode")).isEqualTo("prefer");
+    }
+
+    @Test
+    void buildConfigAcceptsPostgresScheme() {
+        Configuration config = DebeziumSchemaReader.buildConfig(
+                "postgres://alice:secret@pg.example.com/llm_obs",
+                "topicPrefix");
+
+        assertThat(config.getString("database.hostname")).isEqualTo("pg.example.com");
+    }
+
+    @Test
+    void buildConfigDecodesPercentEncodedCredentials() {
+        Configuration config = DebeziumSchemaReader.buildConfig(
+                "postgresql://us%40r:p%40ss@pg.example.com/llm_obs",
+                "topicPrefix");
+
+        assertThat(config.getString("database.user")).isEqualTo("us@r");
+        assertThat(config.getString("database.password")).isEqualTo("p@ss");
+    }
+
+    @Test
+    void buildConfigHandlesUsernameOnly() {
+        Configuration config = DebeziumSchemaReader.buildConfig(
+                "postgresql://alice@pg.example.com/llm_obs",
+                "topicPrefix");
+
+        assertThat(config.getString("database.user")).isEqualTo("alice");
+        assertThat(config.getString("database.password")).isEqualTo("");
+    }
+
+    @Test
+    void buildConfigRejectsNullOrBlank() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(null, "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig("   ", "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+
+    @Test
+    void buildConfigRejectsWrongScheme() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
+                "mysql://alice:secret@pg.example.com/llm_obs", "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("postgresql://");
+    }
+
+    @Test
+    void buildConfigRejectsMissingHost() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
+                "postgresql:///llm_obs", "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing the host");
+    }
+
+    @Test
+    void buildConfigRejectsMissingDatabase() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
+                "postgresql://alice:secret@pg.example.com", "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing the database");
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
+                "postgresql://alice:secret@pg.example.com/", "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing the database");
+    }
+
+    @Test
+    void buildConfigRejectsMalformedUrl() {
+        assertThatThrownBy(() -> DebeziumSchemaReader.buildConfig(
+                "not a valid uri", "topicPrefix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid connection_string");
+    }
+}


### PR DESCRIPTION
## Summary

This PR makes the `debezium-schema-translator` open its Postgres connection per `POST` request from a `connection_string` supplied in the request body, instead of holding a singleton connection built from `POSTGRES_*` environment variables at startup.

1. `SchemaRegistrationRequest` gains a required `connection_string` field, and `RegisterSchemasHandler` returns `400` when it is missing, blank, or malformed (automated, no PR).
2. `DebeziumSchemaReader.readSchemas` opens a temporary `PostgresConnection` to detect the database charset, opens the main `PostgresConnection`, reads the requested table schemas via the same machinery `PostgresConnectorTask.start` uses, and closes everything via try-with-resources (automated, no PR).
3. `TranslatorConfig` drops `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DATABASE`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_SSL_MODE`, and the unused `toSchemaRegistryConfig`. Only `SCHEMA_REGISTRY_URL`, `TOPIC_PREFIX`, and `HTTP_PORT` remain.

## Testing

`mvn -pl debezium-schema-translator verify` passes: 37 unit tests and 8 integration tests, including new ones.
Local development test from the README also works as before with the new connection string.
