### PR TITLE
[MARS-6329] Return structured column diff on schema incompatibility

### DIFF
--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/api/RegisterSchemasHandler.java
@@ -9,7 +9,9 @@ import io.debezium.schematranslator.model.ErrorResponse;
 import io.debezium.schematranslator.model.RegisteredSchema;
 import io.debezium.schematranslator.model.SchemaRegistrationRequest;
 import io.debezium.schematranslator.model.SchemaRegistrationResponse;
+import io.debezium.schematranslator.model.ColumnEvolution;
 import io.debezium.schematranslator.schema.AvroSchemaConverter;
+import io.debezium.schematranslator.schema.AvroSchemaDiffAnalyzer;
 import io.debezium.schematranslator.schema.DebeziumSchemaReader;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher;
 import io.debezium.schematranslator.schema.SchemaRegistryPublisher.SchemaIncompatibilityException;
@@ -34,6 +36,7 @@ public class RegisterSchemasHandler implements HttpHandler {
     private final DebeziumSchemaReader schemaReader;
     private final AvroSchemaConverter avroConverter;
     private final SchemaRegistryPublisher publisher;
+    private final AvroSchemaDiffAnalyzer diffAnalyzer;
 
     public RegisterSchemasHandler(DebeziumSchemaReader schemaReader,
                                   AvroSchemaConverter avroConverter,
@@ -42,6 +45,7 @@ public class RegisterSchemasHandler implements HttpHandler {
         this.schemaReader = schemaReader;
         this.avroConverter = avroConverter;
         this.publisher = publisher;
+        this.diffAnalyzer = new AvroSchemaDiffAnalyzer();
     }
 
     @Override
@@ -125,7 +129,10 @@ public class RegisterSchemasHandler implements HttpHandler {
             }
             catch (SchemaIncompatibilityException e) {
                 LOGGER.warn("Schema incompatibility for table '{}': {}", originalTableName, e.getMessage());
-                incompatibilityErrors.add(new ErrorResponse.SchemaError(e.getMessage(), e.getOldSchema(), e.getNewSchema()));
+                List<ColumnEvolution> columns = diffAnalyzer.diff(e.getOldSchema(), e.getNewSchema());
+                incompatibilityErrors.add(new ErrorResponse.SchemaError(
+                        e.getMessage(), e.getOldSchema(), e.getNewSchema(),
+                        columns.isEmpty() ? null : columns));
             }
             catch (IOException e) {
                 LOGGER.error("Failed to register schema for table '{}'", originalTableName, e);

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ColumnEvolution.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ColumnEvolution.java
@@ -1,0 +1,95 @@
+package io.debezium.schematranslator.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Describes a single column-level change between two incompatible schemas.
+ *
+ * <p>Each change carries both a Postgres-style {@code label} (e.g. "nullable timestamp with
+ * time zone") and the concise Avro-level {@code avro} form (e.g. {@code ["null", ZonedTimestamp]}),
+ * so consumers can render a meaningful diff without re-parsing the raw Avro schemas.
+ */
+public class ColumnEvolution {
+
+    /** Kind of change applied to a column. */
+    public enum ChangeType {
+        MODIFIED("modified"),
+        ADDED("added"),
+        REMOVED("removed");
+
+        private final String value;
+
+        ChangeType(String value) {
+            this.value = value;
+        }
+
+        @JsonProperty
+        public String getValue() {
+            return value;
+        }
+    }
+
+    @JsonProperty("column")
+    private final String column;
+
+    @JsonProperty("change")
+    private final String change;
+
+    @JsonProperty("old")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final TypeRef oldType;
+
+    @JsonProperty("new")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final TypeRef newType;
+
+    public ColumnEvolution(String column, ChangeType change, TypeRef oldType, TypeRef newType) {
+        this.column = column;
+        this.change = change.getValue();
+        this.oldType = oldType;
+        this.newType = newType;
+    }
+
+    public String getColumn() {
+        return column;
+    }
+
+    public String getChange() {
+        return change;
+    }
+
+    public TypeRef getOldType() {
+        return oldType;
+    }
+
+    public TypeRef getNewType() {
+        return newType;
+    }
+
+    /**
+     * A column type rendered two ways: a human-readable Postgres-style {@code label} and the
+     * concise Avro-level {@code avro} form.
+     */
+    public static class TypeRef {
+
+        @JsonProperty("label")
+        private final String label;
+
+        @JsonProperty("avro")
+        private final String avro;
+
+        public TypeRef(String label, String avro) {
+            this.label = label;
+            this.avro = avro;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getAvro() {
+            return avro;
+        }
+    }
+}

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ErrorResponse.java
@@ -41,10 +41,15 @@ public class ErrorResponse {
         @JsonProperty("new_schema")
         private final String newSchema;
 
-        public SchemaError(String message, String oldSchema, String newSchema) {
+        @JsonProperty("columns")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private final List<ColumnEvolution> columns;
+
+        public SchemaError(String message, String oldSchema, String newSchema, List<ColumnEvolution> columns) {
             this.message = message;
             this.oldSchema = oldSchema;
             this.newSchema = newSchema;
+            this.columns = columns;
         }
 
         public String getMessage() {
@@ -57,6 +62,10 @@ public class ErrorResponse {
 
         public String getNewSchema() {
             return newSchema;
+        }
+
+        public List<ColumnEvolution> getColumns() {
+            return columns;
         }
     }
 

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
@@ -44,6 +44,19 @@ public class AvroSchemaDiffAnalyzer {
         DEBEZIUM_TYPE_MAP.put(io.debezium.data.Bits.LOGICAL_NAME, "bit");
         DEBEZIUM_TYPE_MAP.put(io.debezium.connector.postgresql.data.Ltree.LOGICAL_NAME, "ltree");
         DEBEZIUM_TYPE_MAP.put(io.debezium.data.Xml.LOGICAL_NAME, "xml");
+        // NUMERIC/DECIMAL and MONEY in the default precise mode (fixed scale -> Decimal, variable
+        // scale -> VariableScaleDecimal). In double/string modes they serialize as plain double or
+        // string and are covered by AVRO_PRIMITIVE_MAP instead.
+        DEBEZIUM_TYPE_MAP.put(org.apache.kafka.connect.data.Decimal.LOGICAL_NAME, "numeric");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.VariableScaleDecimal.LOGICAL_NAME, "numeric");
+        // PostGIS types.
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.geometry.Geometry.LOGICAL_NAME, "geometry");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.geometry.Geography.LOGICAL_NAME, "geography");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.geometry.Point.LOGICAL_NAME, "point");
+        // pgvector types.
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.vector.DoubleVector.LOGICAL_NAME, "vector");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.vector.FloatVector.LOGICAL_NAME, "halfvec");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.vector.SparseDoubleVector.LOGICAL_NAME, "sparsevec");
         DEBEZIUM_TYPE_MAP.put(io.debezium.time.ZonedTimestamp.SCHEMA_NAME, "timestamp with time zone");
         DEBEZIUM_TYPE_MAP.put(io.debezium.time.ZonedTime.SCHEMA_NAME, "time with time zone");
         DEBEZIUM_TYPE_MAP.put(io.debezium.time.Timestamp.SCHEMA_NAME, "timestamp");

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
@@ -68,6 +68,16 @@ public class AvroSchemaDiffAnalyzer {
         DEBEZIUM_TYPE_MAP.put(io.debezium.time.NanoTime.SCHEMA_NAME, "time (nanoseconds)");
         DEBEZIUM_TYPE_MAP.put(io.debezium.time.Interval.SCHEMA_NAME, "interval");
         DEBEZIUM_TYPE_MAP.put(io.debezium.time.MicroDuration.SCHEMA_NAME, "interval (microseconds)");
+        // Temporal types under time.precision.mode=connect (Kafka Connect logical types). Timestamp
+        // is registered before Time because "...data.Time" is a substring of "...data.Timestamp"
+        // and the partial-name fallback below matches on containment.
+        DEBEZIUM_TYPE_MAP.put(org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME, "timestamp");
+        DEBEZIUM_TYPE_MAP.put(org.apache.kafka.connect.data.Date.LOGICAL_NAME, "date");
+        DEBEZIUM_TYPE_MAP.put(org.apache.kafka.connect.data.Time.LOGICAL_NAME, "time");
+        // Temporal types under time.precision.mode=isostring (ISO-8601 strings).
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.IsoTimestamp.SCHEMA_NAME, "timestamp");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.IsoDate.SCHEMA_NAME, "date");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.IsoTime.SCHEMA_NAME, "time");
 
         AVRO_PRIMITIVE_MAP.put("string", "text");
         AVRO_PRIMITIVE_MAP.put("int", "integer");

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
@@ -32,23 +32,29 @@ public class AvroSchemaDiffAnalyzer {
     private static final Map<String, String> AVRO_PRIMITIVE_MAP = new LinkedHashMap<>();
 
     static {
-        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Uuid", "uuid");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Json", "jsonb");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Enum", "enum");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Bits", "bit");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Ltree", "ltree");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Xml", "xml");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.ZonedTimestamp", "timestamp with time zone");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.ZonedTime", "time with time zone");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Timestamp", "timestamp");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.MicroTimestamp", "timestamp (microseconds)");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.NanoTimestamp", "timestamp (nanoseconds)");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Date", "date");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Time", "time");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.MicroTime", "time (microseconds)");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.NanoTime", "time (nanoseconds)");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Interval", "interval");
-        DEBEZIUM_TYPE_MAP.put("io.debezium.time.MicroDuration", "interval (microseconds)");
+        // Keys are sourced from Debezium's own logical-type name constants (rather than literal
+        // strings) so they stay in lockstep with the library and fail to compile if a type is
+        // renamed or removed. The Postgres-style label values, by contrast, must be authored here:
+        // Debezium models the forward Postgres-type -> schema direction in the connector's type
+        // registry (which needs a live column/OID), but exposes no reverse logical-type -> Postgres
+        // label mapping, and at diff time we only have the Avro schema, not the source columns.
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.Uuid.LOGICAL_NAME, "uuid");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.Json.LOGICAL_NAME, "jsonb");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.Enum.LOGICAL_NAME, "enum");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.Bits.LOGICAL_NAME, "bit");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.connector.postgresql.data.Ltree.LOGICAL_NAME, "ltree");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.data.Xml.LOGICAL_NAME, "xml");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.ZonedTimestamp.SCHEMA_NAME, "timestamp with time zone");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.ZonedTime.SCHEMA_NAME, "time with time zone");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.Timestamp.SCHEMA_NAME, "timestamp");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.MicroTimestamp.SCHEMA_NAME, "timestamp (microseconds)");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.NanoTimestamp.SCHEMA_NAME, "timestamp (nanoseconds)");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.Date.SCHEMA_NAME, "date");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.Time.SCHEMA_NAME, "time");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.MicroTime.SCHEMA_NAME, "time (microseconds)");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.NanoTime.SCHEMA_NAME, "time (nanoseconds)");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.Interval.SCHEMA_NAME, "interval");
+        DEBEZIUM_TYPE_MAP.put(io.debezium.time.MicroDuration.SCHEMA_NAME, "interval (microseconds)");
 
         AVRO_PRIMITIVE_MAP.put("string", "text");
         AVRO_PRIMITIVE_MAP.put("int", "integer");

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
@@ -1,0 +1,227 @@
+package io.debezium.schematranslator.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.debezium.schematranslator.model.ColumnEvolution;
+import io.debezium.schematranslator.model.ColumnEvolution.TypeRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Computes a column-level diff between two incompatible Debezium Envelope Avro schemas.
+ *
+ * <p>Both schemas are the JSON produced by the Schema Registry / Avro. The analyzer walks the
+ * {@code before} field down to its {@code Value} record and compares each column's type, emitting
+ * {@link ColumnEvolution} entries describing what changed. Each change carries both a Postgres-style
+ * label (e.g. "nullable timestamp with time zone") and the concise Avro-level form (e.g.
+ * {@code ["null", ZonedTimestamp]}) so consumers do not need to re-parse the raw schemas.
+ */
+public class AvroSchemaDiffAnalyzer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AvroSchemaDiffAnalyzer.class);
+
+    /** Maps Debezium logical type names (Avro {@code connect.name}) to Postgres-style labels. */
+    private static final Map<String, String> DEBEZIUM_TYPE_MAP = new LinkedHashMap<>();
+
+    /** Maps Avro primitive type names to Postgres-style labels. */
+    private static final Map<String, String> AVRO_PRIMITIVE_MAP = new LinkedHashMap<>();
+
+    static {
+        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Uuid", "uuid");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Json", "jsonb");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Enum", "enum");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Bits", "bit");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Ltree", "ltree");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.data.Xml", "xml");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.ZonedTimestamp", "timestamp with time zone");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.ZonedTime", "time with time zone");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Timestamp", "timestamp");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.MicroTimestamp", "timestamp (microseconds)");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.NanoTimestamp", "timestamp (nanoseconds)");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Date", "date");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Time", "time");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.MicroTime", "time (microseconds)");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.NanoTime", "time (nanoseconds)");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.Interval", "interval");
+        DEBEZIUM_TYPE_MAP.put("io.debezium.time.MicroDuration", "interval (microseconds)");
+
+        AVRO_PRIMITIVE_MAP.put("string", "text");
+        AVRO_PRIMITIVE_MAP.put("int", "integer");
+        AVRO_PRIMITIVE_MAP.put("long", "bigint");
+        AVRO_PRIMITIVE_MAP.put("float", "real");
+        AVRO_PRIMITIVE_MAP.put("double", "double precision");
+        AVRO_PRIMITIVE_MAP.put("boolean", "boolean");
+        AVRO_PRIMITIVE_MAP.put("bytes", "bytea");
+        AVRO_PRIMITIVE_MAP.put("null", "null");
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Compares the column-level fields between two Debezium Envelope schemas.
+     *
+     * @param oldSchemaJson the previously registered Avro schema (JSON)
+     * @param newSchemaJson the incoming Avro schema (JSON)
+     * @return the list of column changes; empty if either schema cannot be parsed
+     */
+    public List<ColumnEvolution> diff(String oldSchemaJson, String newSchemaJson) {
+        List<ColumnEvolution> changes = new ArrayList<>();
+
+        Map<String, JsonNode> oldFields;
+        Map<String, JsonNode> newFields;
+        try {
+            oldFields = valueFields(objectMapper.readTree(oldSchemaJson));
+            newFields = valueFields(objectMapper.readTree(newSchemaJson));
+        }
+        catch (Exception e) {
+            LOGGER.warn("Could not parse schemas for column diff: {}", e.getMessage());
+            return changes;
+        }
+
+        for (Map.Entry<String, JsonNode> entry : oldFields.entrySet()) {
+            String column = entry.getKey();
+            JsonNode oldType = entry.getValue();
+            JsonNode newType = newFields.get(column);
+            if (newType == null) {
+                changes.add(new ColumnEvolution(column, ColumnEvolution.ChangeType.REMOVED,
+                        new TypeRef(typeLabel(oldType), typeShort(oldType)), null));
+                continue;
+            }
+            if (!oldType.equals(newType)) {
+                String oldLabel = typeLabel(oldType);
+                String newLabel = typeLabel(newType);
+                if (!oldLabel.equals(newLabel)) {
+                    changes.add(new ColumnEvolution(column, ColumnEvolution.ChangeType.MODIFIED,
+                            new TypeRef(oldLabel, typeShort(oldType)),
+                            new TypeRef(newLabel, typeShort(newType))));
+                }
+            }
+        }
+
+        for (Map.Entry<String, JsonNode> entry : newFields.entrySet()) {
+            String column = entry.getKey();
+            if (!oldFields.containsKey(column)) {
+                JsonNode newType = entry.getValue();
+                changes.add(new ColumnEvolution(column, ColumnEvolution.ChangeType.ADDED,
+                        null, new TypeRef(typeLabel(newType), typeShort(newType))));
+            }
+        }
+
+        return changes;
+    }
+
+    /**
+     * Extracts the column name to type-node mapping from an Envelope schema's {@code before.Value}
+     * record. Insertion order is preserved.
+     */
+    private static Map<String, JsonNode> valueFields(JsonNode envelope) {
+        Map<String, JsonNode> fields = new LinkedHashMap<>();
+        JsonNode envelopeFields = envelope.get("fields");
+        if (envelopeFields == null || !envelopeFields.isArray()) {
+            return fields;
+        }
+        for (JsonNode field : envelopeFields) {
+            if (!"before".equals(text(field, "name"))) {
+                continue;
+            }
+            JsonNode type = field.get("type");
+            if (type == null || !type.isArray()) {
+                continue;
+            }
+            for (JsonNode candidate : type) {
+                if (candidate.isObject() && "Value".equals(text(candidate, "name"))) {
+                    JsonNode valueFields = candidate.get("fields");
+                    if (valueFields != null && valueFields.isArray()) {
+                        for (JsonNode valueField : valueFields) {
+                            String name = text(valueField, "name");
+                            JsonNode fieldType = valueField.get("type");
+                            if (name != null && fieldType != null) {
+                                fields.put(name, fieldType);
+                            }
+                        }
+                    }
+                    return fields;
+                }
+            }
+        }
+        return fields;
+    }
+
+    /**
+     * Returns a concise Avro-level label: the last segment of {@code connect.name}, the primitive
+     * type name, or a bracketed union (e.g. {@code ["null", ZonedTimestamp]}).
+     */
+    static String typeShort(JsonNode type) {
+        if (type.isArray()) {
+            List<String> parts = new ArrayList<>();
+            for (JsonNode element : type) {
+                if (element.isTextual() && "null".equals(element.asText())) {
+                    parts.add("\"null\"");
+                }
+                else {
+                    parts.add(typeShort(element));
+                }
+            }
+            return "[" + String.join(", ", parts) + "]";
+        }
+        if (type.isObject()) {
+            String connectName = text(type, "connect.name");
+            if (connectName != null && !connectName.isEmpty()) {
+                int dot = connectName.lastIndexOf('.');
+                return dot >= 0 ? connectName.substring(dot + 1) : connectName;
+            }
+            String raw = text(type, "type");
+            return raw != null ? raw : "unknown";
+        }
+        return type.asText();
+    }
+
+    /**
+     * Returns a short Postgres-style label for an Avro field type. Unions with {@code null} are
+     * rendered as "nullable &lt;label&gt;".
+     */
+    static String typeLabel(JsonNode type) {
+        if (type.isArray()) {
+            JsonNode firstNonNull = null;
+            for (JsonNode element : type) {
+                if (!(element.isTextual() && "null".equals(element.asText()))) {
+                    firstNonNull = element;
+                    break;
+                }
+            }
+            String label = firstNonNull != null ? typeLabel(firstNonNull) : "null";
+            return "nullable " + label;
+        }
+        if (type.isObject()) {
+            String connectName = text(type, "connect.name");
+            if (connectName != null) {
+                if (DEBEZIUM_TYPE_MAP.containsKey(connectName)) {
+                    return DEBEZIUM_TYPE_MAP.get(connectName);
+                }
+                // Partial match for versioned or namespaced names not in the map.
+                for (Map.Entry<String, String> entry : DEBEZIUM_TYPE_MAP.entrySet()) {
+                    if (connectName.contains(entry.getKey())) {
+                        return entry.getValue();
+                    }
+                }
+            }
+            String raw = text(type, "type");
+            if (raw == null) {
+                raw = "unknown";
+            }
+            return AVRO_PRIMITIVE_MAP.getOrDefault(raw, raw);
+        }
+        String raw = type.asText();
+        return AVRO_PRIMITIVE_MAP.getOrDefault(raw, raw);
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && value.isTextual() ? value.asText() : null;
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/api/RegisterSchemasHandlerTest.java
@@ -161,6 +161,55 @@ class RegisterSchemasHandlerTest {
     }
 
     @Test
+    void schemaIncompatibilityIncludesStructuredColumnDiff() throws Exception {
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
+        setupSchemaReaderAndConverter();
+        String oldSchema = """
+                {"type": "record", "name": "Envelope", "fields": [
+                  {"name": "before", "type": ["null", {"type": "record", "name": "Value", "fields": [
+                    {"name": "ttl", "type": ["null", {"type": "string", "connect.name": "io.debezium.time.ZonedTimestamp"}]}
+                  ]}]}
+                ]}""";
+        String newSchema = """
+                {"type": "record", "name": "Envelope", "fields": [
+                  {"name": "before", "type": ["null", {"type": "record", "name": "Value", "fields": [
+                    {"name": "ttl", "type": {"type": "string", "connect.name": "io.debezium.time.ZonedTimestamp"}}
+                  ]}]}
+                ]}""";
+        doThrow(new SchemaIncompatibilityException("incompatible schema", new Exception(), oldSchema, newSchema))
+                .when(publisher).register(any(), any(), any());
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(409), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        JsonNode columns = response.get("error").get("errors").get(0).get("columns");
+        assertThat(columns).hasSize(1);
+        JsonNode ttl = columns.get(0);
+        assertThat(ttl.get("column").asText()).isEqualTo("ttl");
+        assertThat(ttl.get("change").asText()).isEqualTo("modified");
+        assertThat(ttl.get("old").get("label").asText()).isEqualTo("nullable timestamp with time zone");
+        assertThat(ttl.get("old").get("avro").asText()).isEqualTo("[\"null\", ZonedTimestamp]");
+        assertThat(ttl.get("new").get("label").asText()).isEqualTo("timestamp with time zone");
+        assertThat(ttl.get("new").get("avro").asText()).isEqualTo("ZonedTimestamp");
+    }
+
+    @Test
+    void schemaIncompatibilityOmitsColumnsWhenSchemasUnparseable() throws Exception {
+        HttpExchange exchange = mockExchange("POST", REQUEST_BODY);
+        setupSchemaReaderAndConverter();
+        doThrow(new SchemaIncompatibilityException("incompatible schema", new Exception(),
+                "{\"old\":true}", "{\"new\":true}"))
+                .when(publisher).register(any(), any(), any());
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(eq(409), anyLong());
+        JsonNode response = objectMapper.readTree(responseBody.toString(StandardCharsets.UTF_8));
+        assertThat(response.get("error").get("errors").get(0).has("columns")).isFalse();
+    }
+
+    @Test
     void multipleSchemaIncompatibilitiesReturnsAllErrors() throws Exception {
         HttpExchange exchange = mockExchange(
                 "POST",

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
@@ -1,0 +1,141 @@
+package io.debezium.schematranslator.schema;
+
+import io.debezium.schematranslator.model.ColumnEvolution;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AvroSchemaDiffAnalyzerTest {
+
+    private final AvroSchemaDiffAnalyzer analyzer = new AvroSchemaDiffAnalyzer();
+
+    /**
+     * Wraps a {@code before.Value} field fragment into a full Debezium Envelope schema, the shape
+     * the Schema Registry returns and that the analyzer walks.
+     */
+    private static String envelope(String valueFields) {
+        return """
+                {
+                  "type": "record",
+                  "name": "Envelope",
+                  "namespace": "test.public.users",
+                  "fields": [
+                    {
+                      "name": "before",
+                      "type": ["null", {
+                        "type": "record",
+                        "name": "Value",
+                        "fields": [%s]
+                      }]
+                    },
+                    {"name": "op", "type": "string"}
+                  ]
+                }
+                """.formatted(valueFields);
+    }
+
+    private static final String ZONED_TIMESTAMP =
+            "{\"type\": \"string\", \"connect.name\": \"io.debezium.time.ZonedTimestamp\"}";
+
+    @Test
+    void detectsNullabilityAndTypeNarrowing() {
+        // 'ttl' goes from nullable timestamp-with-tz to non-nullable — the ticket's example.
+        String oldSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"ttl\", \"type\": [\"null\", " + ZONED_TIMESTAMP + "]}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"ttl\", \"type\": " + ZONED_TIMESTAMP + "}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        ColumnEvolution ttl = changes.get(0);
+        assertThat(ttl.getColumn()).isEqualTo("ttl");
+        assertThat(ttl.getChange()).isEqualTo("modified");
+        assertThat(ttl.getOldType().getLabel()).isEqualTo("nullable timestamp with time zone");
+        assertThat(ttl.getOldType().getAvro()).isEqualTo("[\"null\", ZonedTimestamp]");
+        assertThat(ttl.getNewType().getLabel()).isEqualTo("timestamp with time zone");
+        assertThat(ttl.getNewType().getAvro()).isEqualTo("ZonedTimestamp");
+    }
+
+    @Test
+    void detectsPrimitiveTypeChange() {
+        String oldSchema = envelope("{\"name\": \"count\", \"type\": \"int\"}");
+        String newSchema = envelope("{\"name\": \"count\", \"type\": \"long\"}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        ColumnEvolution count = changes.get(0);
+        assertThat(count.getChange()).isEqualTo("modified");
+        assertThat(count.getOldType().getLabel()).isEqualTo("integer");
+        assertThat(count.getOldType().getAvro()).isEqualTo("int");
+        assertThat(count.getNewType().getLabel()).isEqualTo("bigint");
+        assertThat(count.getNewType().getAvro()).isEqualTo("long");
+    }
+
+    @Test
+    void detectsAddedColumn() {
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"email\", \"type\": \"string\"}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        ColumnEvolution email = changes.get(0);
+        assertThat(email.getColumn()).isEqualTo("email");
+        assertThat(email.getChange()).isEqualTo("added");
+        assertThat(email.getOldType()).isNull();
+        assertThat(email.getNewType().getLabel()).isEqualTo("text");
+        assertThat(email.getNewType().getAvro()).isEqualTo("string");
+    }
+
+    @Test
+    void detectsRemovedColumn() {
+        String oldSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"legacy\", \"type\": \"string\"}");
+        String newSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        ColumnEvolution legacy = changes.get(0);
+        assertThat(legacy.getColumn()).isEqualTo("legacy");
+        assertThat(legacy.getChange()).isEqualTo("removed");
+        assertThat(legacy.getOldType().getLabel()).isEqualTo("text");
+        assertThat(legacy.getNewType()).isNull();
+    }
+
+    @Test
+    void mapsDebeziumLogicalType() {
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"uid\", \"type\": {\"type\": \"string\", \"connect.name\": \"io.debezium.data.Uuid\"}}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        assertThat(changes.get(0).getNewType().getLabel()).isEqualTo("uuid");
+        assertThat(changes.get(0).getNewType().getAvro()).isEqualTo("Uuid");
+    }
+
+    @Test
+    void ignoresIdenticalSchemas() {
+        String schema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"name\", \"type\": \"string\"}");
+
+        assertThat(analyzer.diff(schema, schema)).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyOnMalformedJson() {
+        assertThat(analyzer.diff("not-json", "also-not-json")).isEmpty();
+        assertThat(analyzer.diff("could not retrieve existing schema: timeout",
+                envelope("{\"name\": \"id\", \"type\": \"int\"}"))).isEmpty();
+    }
+}

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
@@ -157,6 +157,21 @@ class AvroSchemaDiffAnalyzerTest {
     }
 
     @Test
+    void mapsAlternateTemporalPrecisionModes() {
+        // connect mode uses Kafka Connect logical types; isostring mode uses io.debezium.time.Iso*.
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"created\", \"type\": {\"type\": \"long\", \"connect.name\": \"org.apache.kafka.connect.data.Timestamp\"}}, "
+                        + "{\"name\": \"updated\", \"type\": {\"type\": \"string\", \"connect.name\": \"io.debezium.time.IsoTimestamp\"}}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).extracting(c -> c.getColumn() + ":" + c.getNewType().getLabel())
+                .containsExactlyInAnyOrder("created:timestamp", "updated:timestamp");
+    }
+
+    @Test
     void ignoresIdenticalSchemas() {
         String schema = envelope(
                 "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"name\", \"type\": \"string\"}");

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
@@ -125,6 +125,38 @@ class AvroSchemaDiffAnalyzerTest {
     }
 
     @Test
+    void mapsDecimalToNumericNotBytea() {
+        // NUMERIC serializes as a Decimal logical type over Avro bytes; it must read as "numeric",
+        // not fall through to the bytes -> "bytea" primitive mapping.
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"amount\", \"type\": {\"type\": \"bytes\", "
+                        + "\"connect.name\": \"org.apache.kafka.connect.data.Decimal\"}}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        assertThat(changes.get(0).getColumn()).isEqualTo("amount");
+        assertThat(changes.get(0).getNewType().getLabel()).isEqualTo("numeric");
+        assertThat(changes.get(0).getNewType().getAvro()).isEqualTo("Decimal");
+    }
+
+    @Test
+    void mapsPostgisAndVectorTypes() {
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"geom\", \"type\": {\"type\": \"bytes\", \"connect.name\": \"io.debezium.data.geometry.Geometry\"}}, "
+                        + "{\"name\": \"embedding\", \"type\": {\"type\": \"array\", \"connect.name\": \"io.debezium.data.DoubleVector\"}}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).extracting(c -> c.getColumn() + ":" + c.getNewType().getLabel())
+                .containsExactlyInAnyOrder("geom:geometry", "embedding:vector");
+    }
+
+    @Test
     void ignoresIdenticalSchemas() {
         String schema = envelope(
                 "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"name\", \"type\": \"string\"}");


### PR DESCRIPTION
## Summary

This PR makes the `debezium-schema-translator` return a structured, column-level diff when a schema is rejected as incompatible, instead of only echoing the raw `old_schema` and `new_schema` strings. A new `ColumnEvolution` model and an `AvroSchemaDiffAnalyzer` walk the two Debezium Envelope schemas down to their `before.Value` records, compare each column, and emit per-column entries describing what changed (`column`, `change` of `modified`/`added`/`removed`, and an `old`/`new` type carrying both a Postgres-style `label` such as `nullable timestamp with time zone` and the concise Avro `avro` form such as `["null", ZonedTimestamp]`). The `ErrorResponse.SchemaError` returned on a 409 now includes these under a `columns` field, so the PGSM CDC CI check can render a meaningful diff directly rather than re-parsing Debezium internals on its side.

## Testing

Added `AvroSchemaDiffAnalyzerTest` covering the nullable-narrowing example from the ticket, primitive type changes, added and removed columns, Debezium logical-type label mapping, identical-schema no-op, and malformed-JSON handling. Extended `RegisterSchemasHandlerTest` with cases asserting the structured `columns` payload on a 409 and that `columns` is omitted when the schemas cannot be parsed. Existing and new tests pass.

Also run locally a docker-compose manual test, which returned the following error with the new field `columns`:
```
{
    "error": {
        "message": "One or more schemas are incompatible with an existing version",
        "errors": [
            {
                "message": "Schema for table public.dataset_records is incompatible with an earlier schema for subject \"test.public.dataset_records-value\": Schema being registered is incompatible with an earlier schema for subject \"test.public.dataset_records-value\", details: [{errorType:'MISSING_UNION_BRANCH', description:'The new schema is missing a type inside a union field at path '/fields/0/type/1' in the old schema', additionalInfo:'reader union lacking writer type: RECORD'}, {errorType:'MISSING_UNION_BRANCH', description:'The new schema is missing a type inside a union field at path '/fields/1/type/1' in the old schema', additionalInfo:'reader union lacking writer type: RECORD'}, {oldSchemaVersion: 1}, {oldSchema: '{\"type\":\"record\",\"name\":\"Envelope\",\"namespace\":\"test.public.dataset_records\",\"fields\":[{\"name\":\"before\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Value\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"ttl\",\"type\":[\"null\",{\"type\":\"string\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.ZonedTimestamp\"}],\"default\":null}],\"connect.name\":\"test.public.dataset_records.Value\"}],\"default\":null},{\"name\":\"after\",\"type\":[\"null\",\"Value\"],\"default\":null},{\"name\":\"source\",\"type\":{\"type\":\"record\",\"name\":\"Source\",\"namespace\":\"io.debezium.connector.postgresql\",\"fields\":[{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"connector\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":\"long\"},{\"name\":\"snapshot\",\"type\":[{\"type\":\"string\",\"connect.version\":1,\"connect.parameters\":{\"allowed\":\"true,first,first_in_data_collection,last_in_data_collection,last,false,incremental\"},\"connect.default\":\"false\",\"connect.name\":\"io.debezium.data.Enum\"},\"null\"],\"default\":\"false\"},{\"name\":\"db\",\"type\":\"string\"},{\"name\":\"sequence\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"schema\",\"type\":\"string\"},{\"name\":\"table\",\"type\":\"string\"},{\"name\":\"txId\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"lsn\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"xmin\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":1,\"connect.name\":\"io.debezium.connector.postgresql.Source\"}},{\"name\":\"transaction\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"block\",\"namespace\":\"event\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"total_order\",\"type\":\"long\"},{\"name\":\"data_collection_order\",\"type\":\"long\"}],\"connect.version\":1,\"connect.name\":\"event.block\"}],\"default\":null},{\"name\":\"op\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":2,\"connect.name\":\"test.public.dataset_records.Envelope\"}'}, {validateFields: 'false', compatibility: 'BACKWARD'}]; error code: 409",
                "old_schema": "{\"type\":\"record\",\"name\":\"Envelope\",\"namespace\":\"test.public.dataset_records\",\"fields\":[{\"name\":\"before\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Value\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"ttl\",\"type\":[\"null\",{\"type\":\"string\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.ZonedTimestamp\"}],\"default\":null}],\"connect.name\":\"test.public.dataset_records.Value\"}],\"default\":null},{\"name\":\"after\",\"type\":[\"null\",\"Value\"],\"default\":null},{\"name\":\"source\",\"type\":{\"type\":\"record\",\"name\":\"Source\",\"namespace\":\"io.debezium.connector.postgresql\",\"fields\":[{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"connector\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":\"long\"},{\"name\":\"snapshot\",\"type\":[{\"type\":\"string\",\"connect.version\":1,\"connect.parameters\":{\"allowed\":\"true,first,first_in_data_collection,last_in_data_collection,last,false,incremental\"},\"connect.default\":\"false\",\"connect.name\":\"io.debezium.data.Enum\"},\"null\"],\"default\":\"false\"},{\"name\":\"db\",\"type\":\"string\"},{\"name\":\"sequence\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"schema\",\"type\":\"string\"},{\"name\":\"table\",\"type\":\"string\"},{\"name\":\"txId\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"lsn\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"xmin\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":1,\"connect.name\":\"io.debezium.connector.postgresql.Source\"}},{\"name\":\"transaction\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"block\",\"namespace\":\"event\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"total_order\",\"type\":\"long\"},{\"name\":\"data_collection_order\",\"type\":\"long\"}],\"connect.version\":1,\"connect.name\":\"event.block\"}],\"default\":null},{\"name\":\"op\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":2,\"connect.name\":\"test.public.dataset_records.Envelope\"}",
                "new_schema": "{\"type\":\"record\",\"name\":\"Envelope\",\"namespace\":\"test.public.dataset_records\",\"fields\":[{\"name\":\"before\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Value\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"ttl\",\"type\":{\"type\":\"string\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.ZonedTimestamp\"}}],\"connect.name\":\"test.public.dataset_records.Value\"}],\"default\":null},{\"name\":\"after\",\"type\":[\"null\",\"Value\"],\"default\":null},{\"name\":\"source\",\"type\":{\"type\":\"record\",\"name\":\"Source\",\"namespace\":\"io.debezium.connector.postgresql\",\"fields\":[{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"connector\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":\"long\"},{\"name\":\"snapshot\",\"type\":[{\"type\":\"string\",\"connect.version\":1,\"connect.parameters\":{\"allowed\":\"true,first,first_in_data_collection,last_in_data_collection,last,false,incremental\"},\"connect.default\":\"false\",\"connect.name\":\"io.debezium.data.Enum\"},\"null\"],\"default\":\"false\"},{\"name\":\"db\",\"type\":\"string\"},{\"name\":\"sequence\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"schema\",\"type\":\"string\"},{\"name\":\"table\",\"type\":\"string\"},{\"name\":\"txId\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"lsn\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"xmin\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":1,\"connect.name\":\"io.debezium.connector.postgresql.Source\"}},{\"name\":\"transaction\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"block\",\"namespace\":\"event\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"total_order\",\"type\":\"long\"},{\"name\":\"data_collection_order\",\"type\":\"long\"}],\"connect.version\":1,\"connect.name\":\"event.block\"}],\"default\":null},{\"name\":\"op\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":2,\"connect.name\":\"test.public.dataset_records.Envelope\"}",
                "columns": [
                    {
                        "column": "ttl",
                        "change": "modified",
                        "old": {
                            "label": "nullable timestamp with time zone",
                            "avro": "[\"null\", ZonedTimestamp]"
                        },
                        "new": {
                            "label": "timestamp with time zone",
                            "avro": "ZonedTimestamp"
                        }
                    }
                ]
            }
        ]
    }
}
```

Other examples of incompatible changes yield:
Making nullable fields not nullable:
```
{
  "error": {
    "message": "One or more schemas are incompatible with an existing version",
    "errors": [
      {
        "message": "Schema for table public.types_demo is incompatible with an earlier schema for subject \"test.public.types_demo-value\": Schema being registered is incompatible with an earlier schema for subject \"test.public.types_demo-value\", details: [{errorType:'MISSING_UNION_BRANCH', description:'The new schema is missing a type inside a union field at path '/fields/0/type/1' in the old schema', additionalInfo:'reader union lacking writer type: RECORD'}, {errorType:'MISSING_UNION_BRANCH', description:'The new schema is missing a type inside a union field at path '/fields/1/type/1' in the old schema', additionalInfo:'reader union lacking writer type: RECORD'}, {oldSchemaVersion: 1}, {oldSchema: '{\"type\":\"record\",\"name\":\"Envelope\",\"namespace\":\"test.public.types_demo\",\"fields\":[{\"name\":\"before\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Value\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"uid\",\"type\":[\"null\",{\"type\":\"string\",\"connect.version\":1,\"connect.name\":\"io.debezium.data.Uuid\"}],\"default\":null},{\"name\":\"doc\",\"type\":[\"null\",{\"type\":\"string\",\"connect.version\":1,\"connect.name\":\"io.debezium.data.Json\"}],\"default\":null},{\"name\":\"count\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"active\",\"type\":[\"null\",\"boolean\"],\"default\":null},{\"name\":\"raw\",\"type\":[\"null\",\"bytes\"],\"default\":null},{\"name\":\"d\",\"type\":[\"null\",{\"type\":\"int\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.Date\"}],\"default\":null},{\"name\":\"t\",\"type\":[\"null\",{\"type\":\"long\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.MicroTime\"}],\"default\":null},{\"name\":\"ts\",\"type\":[\"null\",{\"type\":\"long\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.MicroTimestamp\"}],\"default\":null},{\"name\":\"dur\",\"type\":[\"null\",{\"type\":\"long\",\"connect.version\":1,\"connect.name\":\"io.debezium.time.MicroDuration\"}],\"default\":null},{\"name\":\"ratio\",\"type\":[\"null\",\"double\"],\"default\":null},{\"name\":\"amt\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"VariableScaleDecimal\",\"namespace\":\"io.debezium.data\",\"fields\":[{\"name\":\"scale\",\"type\":\"int\"},{\"name\":\"value\",\"type\":\"bytes\"}],\"connect.doc\":\"Variable scaled decimal\",\"connect.version\":1,\"connect.name\":\"io.debezium.data.VariableScaleDecimal\"}],\"default\":null},{\"name\":\"ip\",\"type\":[\"null\",\"string\"],\"default\":null}],\"connect.name\":\"test.public.types_demo.Value\"}],\"default\":null},{\"name\":\"after\",\"type\":[\"null\",\"Value\"],\"default\":null},{\"name\":\"source\",\"type\":{\"type\":\"record\",\"name\":\"Source\",\"namespace\":\"io.debezium.connector.postgresql\",\"fields\":[{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"connector\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":\"long\"},{\"name\":\"snapshot\",\"type\":[{\"type\":\"string\",\"connect.version\":1,\"connect.parameters\":{\"allowed\":\"true,first,first_in_data_collection,last_in_data_collection,last,false,incremental\"},\"connect.default\":\"false\",\"connect.name\":\"io.debezium.data.Enum\"},\"null\"],\"default\":\"false\"},{\"name\":\"db\",\"type\":\"string\"},{\"name\":\"sequence\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"schema\",\"type\":\"string\"},{\"name\":\"table\",\"type\":\"string\"},{\"name\":\"txId\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"lsn\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"xmin\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":1,\"connect.name\":\"io.debezium.connector.postgresql.Source\"}},{\"name\":\"transaction\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"block\",\"namespace\":\"event\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"total_order\",\"type\":\"long\"},{\"name\":\"data_collection_order\",\"type\":\"long\"}],\"connect.version\":1,\"connect.name\":\"event.block\"}],\"default\":null},{\"name\":\"op\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":2,\"connect.name\":\"test.public.types_demo.Envelope\"}'}, {validateFields: 'false', compatibility: 'BACKWARD'}]; error code: 409",
        "old_schema": "<omitted 3222 chars>",
        "new_schema": "<omitted 2934 chars>",
        "columns": [
          {
            "column": "uid",
            "change": "modified",
            "old": {
              "label": "nullable uuid",
              "avro": "[\"null\", Uuid]"
            },
            "new": {
              "label": "uuid",
              "avro": "Uuid"
            }
          },
          {
            "column": "doc",
            "change": "modified",
            "old": {
              "label": "nullable jsonb",
              "avro": "[\"null\", Json]"
            },
            "new": {
              "label": "jsonb",
              "avro": "Json"
            }
          },
          {
            "column": "count",
            "change": "modified",
            "old": {
              "label": "nullable bigint",
              "avro": "[\"null\", long]"
            },
            "new": {
              "label": "bigint",
              "avro": "long"
            }
          },
          {
            "column": "active",
            "change": "modified",
            "old": {
              "label": "nullable boolean",
              "avro": "[\"null\", boolean]"
            },
            "new": {
              "label": "boolean",
              "avro": "boolean"
            }
          },
          {
            "column": "raw",
            "change": "modified",
            "old": {
              "label": "nullable bytea",
              "avro": "[\"null\", bytes]"
            },
            "new": {
              "label": "bytea",
              "avro": "bytes"
            }
          },
          {
            "column": "d",
            "change": "modified",
            "old": {
              "label": "nullable date",
              "avro": "[\"null\", Date]"
            },
            "new": {
              "label": "date",
              "avro": "Date"
            }
          },
          {
            "column": "t",
            "change": "modified",
            "old": {
              "label": "nullable time (microseconds)",
              "avro": "[\"null\", MicroTime]"
            },
            "new": {
              "label": "time (microseconds)",
              "avro": "MicroTime"
            }
          },
          {
            "column": "ts",
            "change": "modified",
            "old": {
              "label": "nullable timestamp (microseconds)",
              "avro": "[\"null\", MicroTimestamp]"
            },
            "new": {
              "label": "timestamp (microseconds)",
              "avro": "MicroTimestamp"
            }
          },
          {
            "column": "dur",
            "change": "modified",
            "old": {
              "label": "nullable interval (microseconds)",
              "avro": "[\"null\", MicroDuration]"
            },
            "new": {
              "label": "interval (microseconds)",
              "avro": "MicroDuration"
            }
          },
          {
            "column": "ratio",
            "change": "modified",
            "old": {
              "label": "nullable double precision",
              "avro": "[\"null\", double]"
            },
            "new": {
              "label": "double precision",
              "avro": "double"
            }
          },
          {
            "column": "amt",
            "change": "modified",
            "old": {
              "label": "nullable numeric",
              "avro": "[\"null\", VariableScaleDecimal]"
            },
            "new": {
              "label": "numeric",
              "avro": "VariableScaleDecimal"
            }
          },
          {
            "column": "ip",
            "change": "modified",
            "old": {
              "label": "nullable text",
              "avro": "[\"null\", string]"
            },
            "new": {
              "label": "text",
              "avro": "string"
            }
          }
        ]
      }
    ]
  }
}
```

Changing to incompatible type:
```
{
  "error": {
    "message": "One or more schemas are incompatible with an existing version",
    "errors": [
      {
        "message": "Schema for table public.migrations_demo is incompatible with an earlier schema for subject \"test.public.migrations_demo-value\": Schema being registered is incompatible with an earlier schema for subject \"test.public.migrations_demo-value\", details: [{errorType:'MISSING_UNION_BRANCH', description:'The new schema is missing a type inside a union field at path '/fields/0/type/1' in the old schema', additionalInfo:'reader union lacking writer type: RECORD'}, {errorType:'MISSING_UNION_BRANCH', description:'The new schema is missing a type inside a union field at path '/fields/1/type/1' in the old schema', additionalInfo:'reader union lacking writer type: RECORD'}, {oldSchemaVersion: 1}, {oldSchema: '{\"type\":\"record\",\"name\":\"Envelope\",\"namespace\":\"test.public.migrations_demo\",\"fields\":[{\"name\":\"before\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Value\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"price\",\"type\":[\"null\",{\"type\":\"bytes\",\"scale\":2,\"precision\":10,\"connect.version\":1,\"connect.parameters\":{\"scale\":\"2\",\"connect.decimal.precision\":\"10\"},\"connect.name\":\"org.apache.kafka.connect.data.Decimal\",\"logicalType\":\"decimal\"}],\"default\":null},{\"name\":\"qty\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flag\",\"type\":[\"null\",\"boolean\"],\"default\":null}],\"connect.name\":\"test.public.migrations_demo.Value\"}],\"default\":null},{\"name\":\"after\",\"type\":[\"null\",\"Value\"],\"default\":null},{\"name\":\"source\",\"type\":{\"type\":\"record\",\"name\":\"Source\",\"namespace\":\"io.debezium.connector.postgresql\",\"fields\":[{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"connector\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":\"long\"},{\"name\":\"snapshot\",\"type\":[{\"type\":\"string\",\"connect.version\":1,\"connect.parameters\":{\"allowed\":\"true,first,first_in_data_collection,last_in_data_collection,last,false,incremental\"},\"connect.default\":\"false\",\"connect.name\":\"io.debezium.data.Enum\"},\"null\"],\"default\":\"false\"},{\"name\":\"db\",\"type\":\"string\"},{\"name\":\"sequence\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"schema\",\"type\":\"string\"},{\"name\":\"table\",\"type\":\"string\"},{\"name\":\"txId\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"lsn\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"xmin\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":1,\"connect.name\":\"io.debezium.connector.postgresql.Source\"}},{\"name\":\"transaction\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"block\",\"namespace\":\"event\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"total_order\",\"type\":\"long\"},{\"name\":\"data_collection_order\",\"type\":\"long\"}],\"connect.version\":1,\"connect.name\":\"event.block\"}],\"default\":null},{\"name\":\"op\",\"type\":\"string\"},{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_us\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"ts_ns\",\"type\":[\"null\",\"long\"],\"default\":null}],\"connect.version\":2,\"connect.name\":\"test.public.migrations_demo.Envelope\"}'}, {validateFields: 'false', compatibility: 'BACKWARD'}]; error code: 409",
        "old_schema": "<omitted 2263 chars>",
        "new_schema": "<omitted 2065 chars>",
        "columns": [
          {
            "column": "price",
            "change": "modified",
            "old": {
              "label": "nullable numeric",
              "avro": "[\"null\", Decimal]"
            },
            "new": {
              "label": "nullable double precision",
              "avro": "[\"null\", double]"
            }
          },
          {
            "column": "qty",
            "change": "modified",
            "old": {
              "label": "nullable integer",
              "avro": "[\"null\", int]"
            },
            "new": {
              "label": "nullable text",
              "avro": "[\"null\", string]"
            }
          },
          {
            "column": "flag",
            "change": "modified",
            "old": {
              "label": "nullable boolean",
              "avro": "[\"null\", boolean]"
            },
            "new": {
              "label": "nullable text",
              "avro": "[\"null\", string]"
            }
          }
        ]
      }
    ]
  }
}
```
