### PR TITLE
[MARS-6484] Explain why an added column breaks Avro backward compatibility

### DIFF
--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ColumnEvolution.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/model/ColumnEvolution.java
@@ -8,7 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * <p>Each change carries both a Postgres-style {@code label} (e.g. "nullable timestamp with
  * time zone") and the concise Avro-level {@code avro} form (e.g. {@code ["null", ZonedTimestamp]}),
- * so consumers can render a meaningful diff without re-parsing the raw Avro schemas.
+ * so consumers can render a meaningful diff without re-parsing the raw Avro schemas. A column that
+ * is a likely cause of the incompatibility also carries a {@code reason} explaining why.
  */
 public class ColumnEvolution {
 
@@ -44,11 +45,21 @@ public class ColumnEvolution {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final TypeRef newType;
 
+    /** Why this column breaks Avro backward compatibility; {@code null} when it is not the cause. */
+    @JsonProperty("reason")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String reason;
+
     public ColumnEvolution(String column, ChangeType change, TypeRef oldType, TypeRef newType) {
+        this(column, change, oldType, newType, null);
+    }
+
+    public ColumnEvolution(String column, ChangeType change, TypeRef oldType, TypeRef newType, String reason) {
         this.column = column;
         this.change = change.getValue();
         this.oldType = oldType;
         this.newType = newType;
+        this.reason = reason;
     }
 
     public String getColumn() {
@@ -65,6 +76,10 @@ public class ColumnEvolution {
 
     public TypeRef getNewType() {
         return newType;
+    }
+
+    public String getReason() {
+        return reason;
     }
 
     /**

--- a/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
+++ b/debezium-schema-translator/src/main/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzer.java
@@ -114,13 +114,14 @@ public class AvroSchemaDiffAnalyzer {
 
         for (Map.Entry<String, JsonNode> entry : oldFields.entrySet()) {
             String column = entry.getKey();
-            JsonNode oldType = entry.getValue();
-            JsonNode newType = newFields.get(column);
-            if (newType == null) {
+            JsonNode oldType = entry.getValue().get("type");
+            JsonNode newField = newFields.get(column);
+            if (newField == null) {
                 changes.add(new ColumnEvolution(column, ColumnEvolution.ChangeType.REMOVED,
                         new TypeRef(typeLabel(oldType), typeShort(oldType)), null));
                 continue;
             }
+            JsonNode newType = newField.get("type");
             if (!oldType.equals(newType)) {
                 String oldLabel = typeLabel(oldType);
                 String newLabel = typeLabel(newType);
@@ -135,9 +136,11 @@ public class AvroSchemaDiffAnalyzer {
         for (Map.Entry<String, JsonNode> entry : newFields.entrySet()) {
             String column = entry.getKey();
             if (!oldFields.containsKey(column)) {
-                JsonNode newType = entry.getValue();
+                JsonNode newField = entry.getValue();
+                JsonNode newType = newField.get("type");
                 changes.add(new ColumnEvolution(column, ColumnEvolution.ChangeType.ADDED,
-                        null, new TypeRef(typeLabel(newType), typeShort(newType))));
+                        null, new TypeRef(typeLabel(newType), typeShort(newType)),
+                        addedColumnReason(newField, newType)));
             }
         }
 
@@ -145,8 +148,55 @@ public class AvroSchemaDiffAnalyzer {
     }
 
     /**
-     * Extracts the column name to type-node mapping from an Envelope schema's {@code before.Value}
-     * record. Insertion order is preserved.
+     * Explains, in end-user terms, why adding this column breaks backward compatibility, or
+     * {@code null} when the column can be defaulted and is therefore compatible.
+     *
+     * <p>Adding a column stays compatible only if existing records can be given a value for it.
+     * Nullable columns get that for free (they default to null); a {@code NOT NULL} column needs a
+     * usable default, and here it has none. For array columns a Debezium bug can silently drop a
+     * default that was provided, so the message adds a pointer to check whether that is the case
+     * (see https://github.com/debezium/dbz/issues/1269) — we cannot tell from the schema alone.
+     */
+    private static String addedColumnReason(JsonNode field, JsonNode type) {
+        if (field.has("default")) {
+            return null;
+        }
+        String reason = "Adding a column only stays compatible if existing records can be given a "
+                + "value for it. Nullable columns get this automatically (they default to null), but "
+                + "this column was added as NOT NULL without a usable default, so there is no value "
+                + "to fill in for existing records. To fix this, make the column nullable, or give "
+                + "it a default value.";
+        if (containsArray(type)) {
+            reason += " This is an array column: if you did add a default, it may have been dropped "
+                    + "by a known Debezium bug — see https://github.com/debezium/dbz/issues/1269 to "
+                    + "check whether this is your case.";
+        }
+        return reason;
+    }
+
+    /** Whether the Avro type is an {@code array}, or a union that contains one. */
+    private static boolean containsArray(JsonNode type) {
+        if (type == null) {
+            return false;
+        }
+        if (type.isArray()) {
+            for (JsonNode element : type) {
+                if (containsArray(element)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (type.isObject()) {
+            return "array".equals(text(type, "type"));
+        }
+        return "array".equals(type.asText());
+    }
+
+    /**
+     * Extracts the column name to field-node mapping from an Envelope schema's {@code before.Value}
+     * record. The value is the full field node (carrying {@code type} and any {@code default}).
+     * Insertion order is preserved.
      */
     private static Map<String, JsonNode> valueFields(JsonNode envelope) {
         Map<String, JsonNode> fields = new LinkedHashMap<>();
@@ -170,7 +220,7 @@ public class AvroSchemaDiffAnalyzer {
                             String name = text(valueField, "name");
                             JsonNode fieldType = valueField.get("type");
                             if (name != null && fieldType != null) {
-                                fields.put(name, fieldType);
+                                fields.put(name, valueField);
                             }
                         }
                     }

--- a/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
+++ b/debezium-schema-translator/src/test/java/io/debezium/schematranslator/schema/AvroSchemaDiffAnalyzerTest.java
@@ -95,6 +95,55 @@ class AvroSchemaDiffAnalyzerTest {
     }
 
     @Test
+    void addedColumnWithoutDefaultExplainsBackwardIncompatibility() {
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"email\", \"type\": \"string\"}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        assertThat(changes.get(0).getColumn()).isEqualTo("email");
+        assertThat(changes.get(0).getReason())
+                .contains("NOT NULL without a usable default")
+                .doesNotContain("debezium/dbz");
+    }
+
+    @Test
+    void addedColumnWithDefaultHasNoReason() {
+        // A nullable column carries a default (null), so adding it is backward compatible.
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"nickname\", \"type\": [\"null\", \"string\"], \"default\": null}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        assertThat(changes.get(0).getChange()).isEqualTo("added");
+        assertThat(changes.get(0).getReason()).isNull();
+    }
+
+    @Test
+    void addedArrayColumnReasonPointsToUpstreamDebeziumBug() {
+        // text[] NOT NULL DEFAULT '{}' — the array converter omits the default, so it looks
+        // incompatible; the reason must point to the upstream Debezium bug.
+        String oldSchema = envelope("{\"name\": \"id\", \"type\": \"int\"}");
+        String newSchema = envelope(
+                "{\"name\": \"id\", \"type\": \"int\"}, "
+                        + "{\"name\": \"aggregation_keys\", "
+                        + "\"type\": {\"type\": \"array\", \"items\": [\"null\", \"string\"]}}");
+
+        List<ColumnEvolution> changes = analyzer.diff(oldSchema, newSchema);
+
+        assertThat(changes).hasSize(1);
+        assertThat(changes.get(0).getColumn()).isEqualTo("aggregation_keys");
+        assertThat(changes.get(0).getReason())
+                .contains("array")
+                .contains("https://github.com/debezium/dbz/issues/1269");
+    }
+
+    @Test
     void detectsRemovedColumn() {
         String oldSchema = envelope(
                 "{\"name\": \"id\", \"type\": \"int\"}, {\"name\": \"legacy\", \"type\": \"string\"}");


### PR DESCRIPTION
## Summary

This PR improves the failure the schema CI check surfaces when a newly added column makes the schema backward-incompatible. Previously the check only stated that a column was added, which was confusing because adding a column is usually assumed to be backward compatible. The `AvroSchemaDiffAnalyzer` now attaches a per-column `reason` to the `ColumnEvolution` of an added column when it has no usable default, explaining in end-user terms that a column added as `NOT NULL` without a default leaves no value to fill in for existing records, and that the fix is to make the column nullable or give it a default value.

For array columns the message appends a note pointing to the upstream Debezium bug `debezium/dbz#1269`, where a provided array default can be silently dropped, since we cannot tell from the schema alone whether a default was supplied and lost. To support this, `valueFields` now retains the full field node so the analyzer can read the `default` property, and a `containsArray` helper detects array types nested inside unions. The `reason` is a new optional field on `ColumnEvolution` and is omitted for columns that are compatible.

## Testing

Added unit tests to `AvroSchemaDiffAnalyzerTest` covering an added column without a default, an added nullable column with a default (no reason), and an added array column whose reason points to the upstream Debezium issue. Existing and new tests pass.
